### PR TITLE
Fix underwriter allocations API

### DIFF
--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -8,14 +8,44 @@ export async function GET(
 ) {
   try {
     const account = await capitalPool.getUnderwriterAccount(params.address);
-    const allocations = await riskManager.underwriterAllocations(params.address);
+
+    // ── Determine the list of pools this underwriter has allocated capital to ──
+    let poolCount = 0n;
+    try {
+      poolCount = await (riskManager as any).protocolRiskPoolsLength();
+    } catch {
+      // Fallback for older contract versions lacking the length helper
+      while (true) {
+        try {
+          await riskManager.getPoolInfo(poolCount);
+          poolCount++;
+        } catch {
+          break;
+        }
+      }
+    }
+
+    const allocatedPoolIds: number[] = [];
+    for (let i = 0; i < Number(poolCount); i++) {
+      try {
+        const allocated = await riskManager.isAllocatedToPool(
+          params.address,
+          BigInt(i),
+        );
+        if (allocated) allocatedPoolIds.push(i);
+      } catch {
+        // ignore pools that error out
+        continue;
+      }
+    }
+
     const details = {
       totalDepositedAssetPrincipal: account[0],
       yieldChoice: account[1],
       masterShares: account[2],
       withdrawalRequestTimestamp: account[3],
       withdrawalRequestShares: account[4],
-      allocatedPoolIds: allocations,
+      allocatedPoolIds,
     };
     return NextResponse.json({ address: params.address, details });
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- fix GET `/api/underwriters/[address]` so it enumerates pools via `isAllocatedToPool`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68475555aea8832e92a98574a7d2faf8