### PR TITLE
Fix APR parsing and update yield calculation

### DIFF
--- a/frontend/app/components/UnderwriterPanel.js
+++ b/frontend/app/components/UnderwriterPanel.js
@@ -138,8 +138,9 @@ export default function UnderwriterPanel({ displayCurrency }) {
     }
   }
 
-  const totalYield = calculateTotalYield()
   const selectedAdapter = adapters.find((a) => a.id === selectedYield)
+  const baseYield = selectedAdapter?.apr || 0
+  const totalYield = calculateTotalYield() + baseYield
 
   if (!isConnected) {
     return (

--- a/frontend/hooks/useYieldAdapters.js
+++ b/frontend/hooks/useYieldAdapters.js
@@ -11,10 +11,15 @@ export default function useYieldAdapters() {
         const res = await fetch('/api/adapters');
         if (res.ok) {
           const data = await res.json();
+          const decimalsMap = {
+            0: 27, // Aave APR returned with 27 decimals
+            1: 18, // Compound uses 18 decimals
+          };
+
           const list = (data.adapters || []).map((item, index) => {
             let apr = 0;
             try {
-              const decimals = index === 0 ? 27 : 18;
+              const decimals = decimalsMap[index] ?? 18;
               apr = parseFloat(ethers.utils.formatUnits(item.apr || '0', decimals)) * 100;
             } catch {}
             return {


### PR DESCRIPTION
## Summary
- properly parse APR values for Aave and Compound adapters
- include base yield APR when computing total estimated yield

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68495088adf8832ead2de2e9b3bf07f1