### PR TITLE
Add social links footer to sidebar

### DIFF
--- a/frontend/app/components/Sidebar.js
+++ b/frontend/app/components/Sidebar.js
@@ -56,7 +56,7 @@ export default function Sidebar() {
           </nav>
 
           {/* Documentation link moved to bottom, before social links */}
-          <div className="mt-auto">
+          <footer className="mt-auto">
             <Link
               href="/docs"
               className="group flex items-center px-2 py-2 text-sm font-medium rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white mx-2 mb-2"
@@ -85,7 +85,7 @@ export default function Sidebar() {
                 ))}
               </div>
             </div>
-          </div>
+          </footer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a semantic footer section in the Sidebar component
- keeps GitHub, Telegram, Medium and X icons grouped at the bottom

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68495f944eac832e83de4e454169f8db