### PR TITLE
Use subgraph data in analytics and improve coverage

### DIFF
--- a/frontend/hooks/useClaims.js
+++ b/frontend/hooks/useClaims.js
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react'
+import { riskManager } from '../lib/riskManager'
+import { policyNft } from '../lib/policyNft'
 
 export default function useClaims() {
   const [claims, setClaims] = useState([])
@@ -7,11 +9,69 @@ export default function useClaims() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch('/api/claims')
-        if (res.ok) {
-          const data = await res.json()
-          setClaims(data.claims || [])
+        const url = process.env.NEXT_PUBLIC_SUBGRAPH_URL
+        if (!url) throw new Error('NEXT_PUBLIC_SUBGRAPH_URL not set')
+
+        const pageSize = 1000
+        let skip = 0
+        const events = []
+
+        while (true) {
+          const query = `{ genericEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: desc, where: { eventName: "ClaimProcessed" }) { blockNumber timestamp transactionHash data } }`
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query }),
+          })
+          const json = await res.json()
+          const batch = json?.data?.genericEvents || []
+          events.push(...batch)
+          if (batch.length < pageSize) break
+          skip += pageSize
         }
+
+        const claimsData = await Promise.all(
+          events.map(async (ev) => {
+            const [policyIdStr, poolIdStr, claimant, netPayoutStr] = ev.data.split(',')
+            const policyId = Number(policyIdStr)
+            const poolId = Number(poolIdStr)
+
+            let coverage = 0n
+            try {
+              const pol = await policyNft.getPolicy(BigInt(policyId))
+              coverage = BigInt(pol.coverage.toString())
+            } catch (err) {
+              console.error(`Failed to fetch policy ${policyId}`, err)
+            }
+
+            let scale = 0n
+            try {
+              const info = await riskManager.getPoolInfo(poolId)
+              scale = BigInt(info.scaleToProtocolToken.toString())
+            } catch (err) {
+              console.error(`Failed to fetch pool ${poolId}`, err)
+            }
+
+            const protocolTokenAmountReceived = (coverage * scale).toString()
+            const netPayout = BigInt(netPayoutStr)
+            const claimFee = coverage > netPayout ? (coverage - netPayout).toString() : '0'
+
+            return {
+              transactionHash: ev.transactionHash,
+              blockNumber: Number(ev.blockNumber),
+              timestamp: Number(ev.timestamp),
+              policyId,
+              poolId,
+              claimant,
+              coverage: coverage.toString(),
+              netPayoutToClaimant: netPayoutStr,
+              claimFee,
+              protocolTokenAmountReceived,
+            }
+          })
+        )
+
+        setClaims(claimsData)
       } catch (err) {
         console.error('Failed to load claims', err)
       } finally {

--- a/subgraphs/insurance/abis/YieldAdapter.json
+++ b/subgraphs/insurance/abis/YieldAdapter.json
@@ -1,0 +1,20 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "requestedAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "actualAmount", "type": "uint256" }
+    ],
+    "name": "FundsWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "newCapitalPool", "type": "address" }
+    ],
+    "name": "CapitalPoolAddressSet",
+    "type": "event"
+  }
+]

--- a/subgraphs/insurance/src/mapping.ts
+++ b/subgraphs/insurance/src/mapping.ts
@@ -13,6 +13,7 @@ import {
   DistressedAssetRewardsClaimed,
   OwnershipTransferred as RiskManagerOwnershipTransferred
 } from "../generated/RiskManager/RiskManager";
+import { RiskManager } from "../generated/RiskManager/RiskManager";
 import {
   RiskManagerSet,
   BaseYieldAdapterSet,
@@ -39,8 +40,13 @@ import {
 import {
   PolicyPremiumAccountUpdated,
   Transfer,
+  RiskManagerAddressSet,
   OwnershipTransferred as PolicyNFTOwnershipTransferred
 } from "../generated/PolicyNFT/PolicyNFT";
+import {
+  FundsWithdrawn,
+  CapitalPoolAddressSet
+} from "../generated/AaveV3Adapter/YieldAdapter";
 
 function saveGeneric(event: ethereum.Event, name: string): void {
   let id = event.transaction.hash.toHex() + "-" + event.logIndex.toString();
@@ -77,6 +83,13 @@ export function handlePoolAdded(event: PoolAdded): void {
   pool.underlyingAsset = Address.zero();
   pool.protocolToken = event.params.protocolToken;
   pool.protocolCovered = event.params.protocolCovered;
+
+  let rm = RiskManager.bind(event.address);
+  let info = rm.try_getPoolInfo(event.params.poolId);
+  if (!info.reverted) {
+    pool.protocolCovered = info.value.protocolCovered;
+    pool.protocolToken = info.value.protocolTokenToCover;
+  }
   pool.save();
 }
 
@@ -170,4 +183,18 @@ export function handlePolicyNFTOwnershipTransferred(
 ): void {
   saveGeneric(event, "OwnershipTransferred");
   saveOwner(event, event.params.newOwner);
+}
+
+export function handleRiskManagerAddressSet(event: RiskManagerAddressSet): void {
+  saveGeneric(event, "RiskManagerAddressSet");
+}
+
+export function handleFundsWithdrawn(event: FundsWithdrawn): void {
+  saveGeneric(event, "FundsWithdrawn");
+}
+
+export function handleCapitalPoolAddressSet(
+  event: CapitalPoolAddressSet
+): void {
+  saveGeneric(event, "CapitalPoolAddressSet");
 }

--- a/subgraphs/insurance/subgraph.yaml
+++ b/subgraphs/insurance/subgraph.yaml
@@ -158,6 +158,138 @@ dataSources:
           handler: handlePolicyPremiumAccountUpdated
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+        - event: RiskManagerAddressSet(indexed address)
+          handler: handleRiskManagerAddressSet
         - event: OwnershipTransferred(indexed address,indexed address)
           handler: handlePolicyNFTOwnershipTransferred
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: AaveV3Adapter
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: YieldAdapter
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+      abis:
+        - name: YieldAdapter
+          file: ./abis/YieldAdapter.json
+      eventHandlers:
+        - event: FundsWithdrawn(indexed address,uint256,uint256)
+          handler: handleFundsWithdrawn
+        - event: CapitalPoolAddressSet(indexed address)
+          handler: handleCapitalPoolAddressSet
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: CompoundV3Adapter
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: YieldAdapter
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+      abis:
+        - name: YieldAdapter
+          file: ./abis/YieldAdapter.json
+      eventHandlers:
+        - event: FundsWithdrawn(indexed address,uint256,uint256)
+          handler: handleFundsWithdrawn
+        - event: CapitalPoolAddressSet(indexed address)
+          handler: handleCapitalPoolAddressSet
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: EulerAdapter
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: YieldAdapter
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+      abis:
+        - name: YieldAdapter
+          file: ./abis/YieldAdapter.json
+      eventHandlers:
+        - event: FundsWithdrawn(indexed address,uint256,uint256)
+          handler: handleFundsWithdrawn
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: MoonwellAdapter
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: YieldAdapter
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+      abis:
+        - name: YieldAdapter
+          file: ./abis/YieldAdapter.json
+      eventHandlers:
+        - event: FundsWithdrawn(indexed address,uint256,uint256)
+          handler: handleFundsWithdrawn
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: MorhpoAdapter
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: YieldAdapter
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+      abis:
+        - name: YieldAdapter
+          file: ./abis/YieldAdapter.json
+      eventHandlers:
+        - event: FundsWithdrawn(indexed address,uint256,uint256)
+          handler: handleFundsWithdrawn
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: SdaiAdapter
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: YieldAdapter
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+      abis:
+        - name: YieldAdapter
+          file: ./abis/YieldAdapter.json
+      eventHandlers:
+        - event: FundsWithdrawn(indexed address,uint256,uint256)
+          handler: handleFundsWithdrawn
       file: ./src/mapping.ts


### PR DESCRIPTION
## Summary
- query subgraph directly for claims in the frontend
- track additional smart‑contract events in the subgraph
- add a minimal ABI and subgraph data sources for yield adapters

## Testing
- `npm run codegen` and `npm run build` in `subgraphs/insurance`
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68496c5b2384832e9fa194e97f2b5a14