### PR TITLE
Fix chart cleanup for analytics page

### DIFF
--- a/frontend/app/analytics/page.js
+++ b/frontend/app/analytics/page.js
@@ -867,7 +867,10 @@ function LapsedCoverChart({ data }) {
     if (!canvasRef.current || !data) return;
     const el = canvasRef.current;
     const ctx = el.getContext("2d");
-    if (window.lapsedCoverChart) {
+    if (
+      window.lapsedCoverChart &&
+      typeof window.lapsedCoverChart.destroy === "function"
+    ) {
       window.lapsedCoverChart.destroy();
     }
     const dpr = window.devicePixelRatio || 1;
@@ -935,7 +938,10 @@ function LapsedCoverChart({ data }) {
     });
 
     return () => {
-      if (window.lapsedCoverChart) {
+      if (
+        window.lapsedCoverChart &&
+        typeof window.lapsedCoverChart.destroy === "function"
+      ) {
         window.lapsedCoverChart.destroy();
       }
     };


### PR DESCRIPTION
## Summary
- avoid calling `destroy` when `lapsedCoverChart` isn't a Chart instance

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497e1c925c832eb01bc9e4cfe478c2