### PR TITLE
Add frontend and subgraph tests

### DIFF
--- a/frontend/components/ui/__tests__/avatar.test.tsx
+++ b/frontend/components/ui/__tests__/avatar.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Avatar, AvatarImage, AvatarFallback } from '../avatar'
+
+describe('Avatar component', () => {
+  it('shows fallback text', () => {
+    render(
+      <Avatar>
+        <AvatarImage alt="pic" src="pic.png" />
+        <AvatarFallback>AB</AvatarFallback>
+      </Avatar>
+    )
+    const fallback = screen.getByText('AB')
+    expect(fallback).toBeInTheDocument()
+    expect(fallback).toHaveClass('bg-muted')
+  })
+})

--- a/frontend/components/ui/__tests__/input.test.tsx
+++ b/frontend/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Input } from '../input'
+
+describe('Input component', () => {
+  it('passes props to the input element', () => {
+    render(<Input type="password" placeholder="Secret" className="custom" disabled />)
+    const el = screen.getByPlaceholderText('Secret')
+    expect(el).toHaveAttribute('type', 'password')
+    expect(el).toHaveClass('custom')
+    expect(el).toBeDisabled()
+  })
+})

--- a/subgraphs/insurance/tests/poolAdded.test.ts
+++ b/subgraphs/insurance/tests/poolAdded.test.ts
@@ -1,0 +1,17 @@
+import { test, assert, clearStore } from 'matchstick-as/assembly/index'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { handlePoolAdded } from '../src/mapping'
+import { createPoolAddedEvent } from './utils'
+
+test('handlePoolAdded creates Pool and GenericEvent', () => {
+  clearStore()
+  let poolId = BigInt.fromI32(3)
+  let token = Address.fromString('0x0000000000000000000000000000000000000010')
+  let event = createPoolAddedEvent(poolId, token, 5)
+  handlePoolAdded(event)
+
+  assert.entityCount('Pool', 1)
+  assert.fieldEquals('Pool', poolId.toString(), 'protocolToken', token.toHex())
+  assert.fieldEquals('Pool', poolId.toString(), 'protocolCovered', '5')
+  assert.entityCount('GenericEvent', 1)
+})

--- a/subgraphs/insurance/tests/transfer.test.ts
+++ b/subgraphs/insurance/tests/transfer.test.ts
@@ -1,0 +1,23 @@
+import { test, assert, clearStore } from 'matchstick-as/assembly/index'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { Policy } from '../generated/schema'
+import { handleTransfer } from '../src/mapping'
+import { createTransferEvent } from './utils'
+
+test('handleTransfer updates Policy owner and logs event', () => {
+  clearStore()
+  let oldOwner = Address.fromString('0x0000000000000000000000000000000000000001')
+  let newOwner = Address.fromString('0x0000000000000000000000000000000000000002')
+  let policy = new Policy('1')
+  policy.owner = oldOwner
+  policy.pool = '0'
+  policy.coverageAmount = BigInt.fromI32(0)
+  policy.premiumPaid = BigInt.fromI32(0)
+  policy.save()
+
+  let event = createTransferEvent(oldOwner, newOwner, BigInt.fromI32(1))
+  handleTransfer(event)
+
+  assert.fieldEquals('Policy', '1', 'owner', newOwner.toHex())
+  assert.entityCount('GenericEvent', 1)
+})

--- a/subgraphs/insurance/tests/utils.ts
+++ b/subgraphs/insurance/tests/utils.ts
@@ -30,3 +30,33 @@ export function createPolicyCreatedEvent(
   event.parameters.push(new ethereum.EventParam('premiumPaid', ethereum.Value.fromUnsignedBigInt(premiumPaid)))
   return event
 }
+
+import { Transfer } from '../generated/PolicyNFT/PolicyNFT'
+
+export function createTransferEvent(
+  from: Address,
+  to: Address,
+  tokenId: BigInt,
+): Transfer {
+  let event = changetype<Transfer>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(new ethereum.EventParam('from', ethereum.Value.fromAddress(from)))
+  event.parameters.push(new ethereum.EventParam('to', ethereum.Value.fromAddress(to)))
+  event.parameters.push(new ethereum.EventParam('tokenId', ethereum.Value.fromUnsignedBigInt(tokenId)))
+  return event
+}
+
+import { PoolAdded } from '../generated/RiskManager/RiskManager'
+
+export function createPoolAddedEvent(
+  poolId: BigInt,
+  protocolToken: Address,
+  protocolCovered: i32,
+): PoolAdded {
+  let event = changetype<PoolAdded>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(new ethereum.EventParam('poolId', ethereum.Value.fromUnsignedBigInt(poolId)))
+  event.parameters.push(new ethereum.EventParam('protocolToken', ethereum.Value.fromAddress(protocolToken)))
+  event.parameters.push(new ethereum.EventParam('protocolCovered', ethereum.Value.fromI32(protocolCovered)))
+  return event
+}


### PR DESCRIPTION
## Summary
- add new UI unit tests for Input and Avatar components
- extend subgraph utility helpers
- test PoolAdded and Transfer mappings

## Testing
- `npm test` in `frontend` *(fails: Failed to resolve import '@/lib/utils')*
- `npm test` in `subgraphs/insurance` *(fails: matchstick not found)*

------
https://chatgpt.com/codex/tasks/task_e_684986cc68b0832eb98036428758b2f5