### PR TITLE
Display yield info in allocation modal

### DIFF
--- a/frontend/app/components/ManageAllocationModal.js
+++ b/frontend/app/components/ManageAllocationModal.js
@@ -5,7 +5,9 @@ import usePools from "../../hooks/usePools";
 import useUnderwriterDetails from "../../hooks/useUnderwriterDetails";
 import { useAccount } from "wagmi";
 import Image from "next/image";
+import Link from "next/link";
 import { getProtocolLogo, getProtocolName } from "../config/tokenNameMap";
+import { formatPercentage } from "../utils/formatting";
 import { getRiskManagerWithSigner } from "../../lib/riskManager";
 
 export default function ManageAllocationModal({ isOpen, onClose }) {
@@ -44,31 +46,40 @@ export default function ManageAllocationModal({ isOpen, onClose }) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Manage Protocol Allocation">
       <div className="space-y-4">
-        {pools.map((pool) => (
-          <div
-            key={pool.id}
-            className="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 pb-2"
-          >
-            <div className="flex items-center">
-              <Image
-                src={getProtocolLogo(pool.id)}
-                alt={getProtocolName(pool.id)}
-                width={32}
-                height={32}
-                className="rounded-full mr-2"
+        {pools.map((pool) => {
+          const yieldRate = Number(pool.underwriterYieldBps || 0) / 100;
+          return (
+            <div
+              key={pool.id}
+              className="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 pb-2"
+            >
+              <div className="flex items-center space-x-2">
+                <Image
+                  src={getProtocolLogo(pool.id)}
+                  alt={getProtocolName(pool.id)}
+                  width={32}
+                  height={32}
+                  className="rounded-full"
+                />
+                <Link
+                  href={`/pool/${pool.id}/${pool.protocolTokenToCover}`}
+                  className="text-sm text-blue-600 hover:underline"
+                >
+                  {getProtocolName(pool.id)}
+                </Link>
+                <span className="text-xs text-gray-500">
+                  {formatPercentage(yieldRate)} APY
+                </span>
+              </div>
+              <input
+                type="checkbox"
+                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                checked={selectedPools.includes(pool.id)}
+                onChange={() => togglePool(pool.id)}
               />
-              <span className="text-sm text-gray-900 dark:text-gray-200">
-                {getProtocolName(pool.id)}
-              </span>
             </div>
-            <input
-              type="checkbox"
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              checked={selectedPools.includes(pool.id)}
-              onChange={() => togglePool(pool.id)}
-            />
-          </div>
-        ))}
+          );
+        })}
       </div>
       <div className="mt-6 flex justify-end">
         <button


### PR DESCRIPTION
## Summary
- show a link to pool details and underwriter yield

## Testing
- `npm test` *(fails: Failed to resolve import "@/lib/utils" in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684986025274832e92eec686c7b6fd05