### PR TITLE
Add Cat Pool deposits section

### DIFF
--- a/frontend/app/api/catpool/user/[address]/route.ts
+++ b/frontend/app/api/catpool/user/[address]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { catPool, provider } from '../../../../../../lib/catPool';
+import ERC20 from '../../../../../../abi/ERC20.json';
+import { ethers } from 'ethers';
+
+export async function GET(_req: Request, { params }: { params: { address: string } }) {
+  try {
+    const addr = params.address.toLowerCase();
+    const catShareAddr = await catPool.catShareToken();
+    const token = new ethers.Contract(catShareAddr, ERC20, provider);
+    const [balance, totalSupply, liquid] = await Promise.all([
+      token.balanceOf(addr),
+      token.totalSupply(),
+      catPool.liquidUsdc(),
+    ]);
+    let value = 0n;
+    if (totalSupply > 0n) {
+      value = (balance * liquid) / totalSupply;
+    }
+    return NextResponse.json({ address: addr, balance: balance.toString(), value: value.toString() });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/app/components/CatPoolDeposits.js
+++ b/frontend/app/components/CatPoolDeposits.js
@@ -1,0 +1,30 @@
+"use client"
+import { useAccount } from "wagmi"
+import { ethers } from "ethers"
+import { formatCurrency } from "../utils/formatting"
+import useCatPoolUserInfo from "../../hooks/useCatPoolUserInfo"
+
+export default function CatPoolDeposits({ displayCurrency }) {
+  const { address } = useAccount()
+  const { info } = useCatPoolUserInfo(address)
+
+  if (!info || info.balance === "0") {
+    return <p className="text-gray-500">No deposits in the Cat Pool.</p>
+  }
+
+  const shares = Number(ethers.utils.formatUnits(info.balance || "0", 18))
+  const value = Number(ethers.utils.formatUnits(info.value || "0", 6))
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between">
+        <span className="text-sm text-gray-500">CatShare Balance</span>
+        <span className="text-sm font-medium text-gray-900 dark:text-white">{shares.toFixed(4)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-sm text-gray-500">Current Value</span>
+        <span className="text-sm font-medium text-gray-900 dark:text-white">{formatCurrency(value, "USD", displayCurrency)}</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -7,6 +7,7 @@ import ActiveCoverages from "../components/ActiveCoverages"
 import UnderwritingPositions from "../components/UnderwritingPositions"
 import { useAccount } from "wagmi"
 import ClaimsSection from "../components/ClaimsSection"
+import CatPoolDeposits from "../components/CatPoolDeposits"
 import useUserPolicies from "../../hooks/useUserPolicies"
 import useUnderwriterDetails from "../../hooks/useUnderwriterDetails"
 
@@ -63,6 +64,11 @@ export default function Dashboard() {
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
           <h2 className="text-xl font-semibold mb-4">Claims & Affected Positions</h2>
           <ClaimsSection displayCurrency={displayCurrency} />
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-xl font-semibold mb-4">My Cat Pool Deposits</h2>
+          <CatPoolDeposits displayCurrency={displayCurrency} />
         </div>
       </div>
     </div>

--- a/frontend/hooks/useCatPoolUserInfo.js
+++ b/frontend/hooks/useCatPoolUserInfo.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+
+export default function useCatPoolUserInfo(address) {
+  const [info, setInfo] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!address) return
+    async function load() {
+      try {
+        const res = await fetch(`/api/catpool/user/${address}`)
+        if (res.ok) {
+          const data = await res.json()
+          setInfo(data)
+        }
+      } catch (err) {
+        console.error('Failed to load cat pool user info', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [address])
+
+  return { info, loading }
+}


### PR DESCRIPTION
## Summary
- expose per-user CatPool info via new API route
- add hook and component for Cat Pool deposits
- show Cat Pool deposits on the dashboard

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*
- `npm run test` in `frontend` *(fails: Cannot find module 'vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_6849a94091fc832ea3313a72ff335d2a