### PR TITLE
Add deallocateCapital to dashboard

### DIFF
--- a/frontend/abi/RiskManager.json
+++ b/frontend/abi/RiskManager.json
@@ -561,24 +561,37 @@
 		"stateMutability": "nonpayable",
 		"type": "function"
 	},
-	{
-		"inputs": [
-			{
-				"internalType": "uint256[]",
-				"name": "_poolIds",
-				"type": "uint256[]"
-			}
-		],
-		"name": "allocateCapital",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [],
-		"name": "capitalPool",
-		"outputs": [
-			{
+        {
+                "inputs": [
+                        {
+                                "internalType": "uint256[]",
+                                "name": "_poolIds",
+                                "type": "uint256[]"
+                        }
+                ],
+                "name": "allocateCapital",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+        },
+        {
+                "inputs": [
+                        {
+                                "internalType": "uint256[]",
+                                "name": "_poolIds",
+                                "type": "uint256[]"
+                        }
+                ],
+                "name": "deallocateCapital",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+        },
+        {
+                "inputs": [],
+                "name": "capitalPool",
+                "outputs": [
+                        {
 				"internalType": "contract ICapitalPool",
 				"name": "",
 				"type": "address"

--- a/subgraphs/insurance/abis/RiskManager.json
+++ b/subgraphs/insurance/abis/RiskManager.json
@@ -548,6 +548,19 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_poolIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "deallocateCapital",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "capitalPool",
     "outputs": [


### PR DESCRIPTION
## Summary
- support capital deallocation from pools in ManageAllocationModal
- update RiskManager ABIs with deallocateCapital function

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails to find vitest)*

------
https://chatgpt.com/codex/tasks/task_e_684b44ae0784832ea714ad3e62f5b5ff