### PR TITLE
Update reserve config display and lighten charts

### DIFF
--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { riskManager } from '../../../lib/riskManager'
+import { capitalPool } from '../../../lib/capitalPool'
+
+export async function GET() {
+  try {
+    const [cooldown, claimFee, notice] = await Promise.all([
+      (riskManager as any).COVER_COOLDOWN_PERIOD(),
+      (riskManager as any).CLAIM_FEE_BPS(),
+      (capitalPool as any).UNDERWRITER_NOTICE_PERIOD(),
+    ])
+    return NextResponse.json({
+      coverCooldownPeriod: cooldown.toString(),
+      claimFeeBps: claimFee.toString(),
+      underwriterNoticePeriod: notice.toString(),
+    })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}

--- a/frontend/app/pool/[protocol]/[token]/page.js
+++ b/frontend/app/pool/[protocol]/[token]/page.js
@@ -7,6 +7,7 @@ import Link from "next/link"
 import Image from "next/image"
 import CoverageModal from "../../../components/CoverageModal"
 import usePools from "../../../../hooks/usePools"
+import useReserveConfig from "../../../../hooks/useReserveConfig"
 import {
   getProtocolName,
   getProtocolDescription,
@@ -74,6 +75,8 @@ export default function PoolDetailsPage() {
   const [utilHistory, setUtilHistory] = useState([])
   const [purchaseModalOpen, setPurchaseModalOpen] = useState(false)
   const [provideModalOpen, setProvideModalOpen] = useState(false)
+
+  const { config: reserveConfig } = useReserveConfig()
 
   const premiumCanvasRef = useRef(null)
   const utilCanvasRef = useRef(null)
@@ -195,10 +198,10 @@ export default function PoolDetailsPage() {
       const chartWidth = width - padding.left - padding.right
       const chartHeight = height - padding.top - padding.bottom
       const isDark = document.documentElement.classList.contains("dark")
-      const bg = isDark ? "#11182b" : "#f9fafb"
-      const grid = isDark ? "rgba(100,116,139,0.2)" : "rgba(203,213,225,0.5)"
-      const text = isDark ? "#cbd5e1" : "#4b5563"
-      const axis = isDark ? "#475569" : "#cbd5e1"
+      const bg = isDark ? "#11182b" : "#ffffff"
+      const grid = isDark ? "rgba(100,116,139,0.2)" : "rgba(203,213,225,0.3)"
+      const text = isDark ? "#cbd5e1" : "#6b7280"
+      const axis = isDark ? "#475569" : "#e5e7eb"
       const rateColor = "#ec4899"
       const optimalColor = "#22c55e"
       const currentColor = "#3b82f6"
@@ -229,7 +232,7 @@ export default function PoolDetailsPage() {
       ctx.lineTo(padding.left, padding.top + chartHeight)
       ctx.stroke()
       ctx.save()
-      ctx.translate(padding.left - 30, padding.top + chartHeight / 2)
+      ctx.translate(padding.left - 45, padding.top + chartHeight / 2)
       ctx.rotate(-Math.PI / 2)
       ctx.textAlign = "center"
       ctx.font = CHART_FONT
@@ -481,8 +484,12 @@ export default function PoolDetailsPage() {
       </div>
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 md:p-6 mb-8">
         <h2 className="text-lg md:text-xl font-semibold mb-4 text-gray-900 dark:text-white">Reserve Configuration</h2>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {[{label:'Reserve Factor',value:'N/A'},{label:'Max LTV',value:'N/A'},{label:'Liq. Threshold',value:'N/A'},{label:'Liq. Penalty',value:'N/A'}].map(item=>(
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {[
+            {label:'Cover Cooldown', value: reserveConfig ? `${reserveConfig.coverCooldownPeriod / 86400}d` : 'N/A'},
+            {label:'Claim Fee', value: reserveConfig ? formatPercentage(reserveConfig.claimFeeBps / 100) : 'N/A'},
+            {label:'Notice Period', value: reserveConfig ? `${reserveConfig.underwriterNoticePeriod / 86400}d` : 'N/A'},
+          ].map(item=>(
             <div key={item.label}><div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 mb-1">{item.label}</div><div className="text-base sm:text-lg font-medium text-gray-800 dark:text-gray-200">{item.value}</div></div>
           ))}
         </div>

--- a/frontend/hooks/useReserveConfig.js
+++ b/frontend/hooks/useReserveConfig.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react'
+
+export default function useReserveConfig() {
+  const [config, setConfig] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/reserve-config')
+        if (res.ok) {
+          const data = await res.json()
+          setConfig({
+            coverCooldownPeriod: Number(data.coverCooldownPeriod || 0),
+            claimFeeBps: Number(data.claimFeeBps || 0),
+            underwriterNoticePeriod: Number(data.underwriterNoticePeriod || 0),
+          })
+        }
+      } catch (err) {
+        console.error('Failed to load reserve config', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  return { config, loading }
+}


### PR DESCRIPTION
## Summary
- add API route to expose reserve-related constants
- add `useReserveConfig` hook for frontend
- display cooldown, claim fee and notice period in Reserve Configuration
- lighten premium rate model chart and shift Y-axis label

## Testing
- `npx hardhat test` *(fails: couldn't download compiler)*
- `npm run test` in `frontend` *(fails: vitest not found)*
- `npm run test` in `subgraphs/insurance` *(fails: matchstick not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4f1141a0832e9c0576f1ff0f771b