### PR TITLE
Fix cat pool deposit display

### DIFF
--- a/frontend/app/catpool/page.js
+++ b/frontend/app/catpool/page.js
@@ -19,6 +19,7 @@ export default function CatPoolPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [depositOpen, setDepositOpen] = useState(false)
   const [withdrawOpen, setWithdrawOpen] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   const adapters = useYieldAdapters()
   const [selectedAdapter, setSelectedAdapter] = useState(null)
@@ -89,7 +90,7 @@ export default function CatPoolPage() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
           <h3 className="text-sm text-gray-500 mb-1">My Deposits</h3>
-          <CatPoolDeposits displayCurrency={displayCurrency} />
+          <CatPoolDeposits displayCurrency={displayCurrency} refreshTrigger={refreshKey} />
         </div>
       </div>
 
@@ -156,8 +157,14 @@ export default function CatPoolPage() {
         token={selectedAdapter?.asset}
         apr={selectedAdapter?.apr ?? 0}
         assetSymbol={selectedAdapter?.assetSymbol || 'USDC'}
+        onActionComplete={() => setRefreshKey((k) => k + 1)}
       />
-      <CatPoolModal isOpen={withdrawOpen} onClose={() => setWithdrawOpen(false)} mode="withdraw" />
+      <CatPoolModal
+        isOpen={withdrawOpen}
+        onClose={() => setWithdrawOpen(false)}
+        mode="withdraw"
+        onActionComplete={() => setRefreshKey((k) => k + 1)}
+      />
     </div>
   )
 }

--- a/frontend/app/components/CatPoolDeposits.js
+++ b/frontend/app/components/CatPoolDeposits.js
@@ -1,12 +1,16 @@
 "use client"
 import { useAccount } from "wagmi"
+import { useEffect } from "react"
 import { ethers } from "ethers"
 import { formatCurrency } from "../utils/formatting"
 import useCatPoolUserInfo from "../../hooks/useCatPoolUserInfo"
-
-export default function CatPoolDeposits({ displayCurrency }) {
+export default function CatPoolDeposits({ displayCurrency, refreshTrigger }) {
   const { address } = useAccount()
-  const { info } = useCatPoolUserInfo(address)
+  const { info, refresh } = useCatPoolUserInfo(address)
+
+  useEffect(() => {
+    refresh()
+  }, [refreshTrigger])
 
   if (!info || info.balance === "0") {
     return <p className="text-gray-500">No deposits in the Cat Pool.</p>

--- a/frontend/app/components/CatPoolModal.js
+++ b/frontend/app/components/CatPoolModal.js
@@ -13,7 +13,7 @@ import {
 import { getERC20WithSigner, getTokenDecimals } from "../../lib/erc20";
 import { getTokenLogo } from "../config/tokenNameMap";
 
-export default function CatPoolModal({ isOpen, onClose, mode, token, apr = 0, assetSymbol = 'USDC' }) {
+export default function CatPoolModal({ isOpen, onClose, mode, token, apr = 0, assetSymbol = 'USDC', onActionComplete }) {
   const isDeposit = mode === "deposit";
   const symbol = isDeposit ? assetSymbol : "CATLP";
   const [amount, setAmount] = useState("");
@@ -95,8 +95,9 @@ export default function CatPoolModal({ isOpen, onClose, mode, token, apr = 0, as
         const tx = await cp.withdrawLiquidity(sharesBn);
         await tx.wait();
       }
-      onClose();
       setAmount("");
+      onActionComplete && onActionComplete();
+      onClose();
     } catch (err) {
       console.error("CatPool action failed", err);
     } finally {

--- a/frontend/hooks/useCatPoolUserInfo.js
+++ b/frontend/hooks/useCatPoolUserInfo.js
@@ -1,26 +1,28 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 
 export default function useCatPoolUserInfo(address) {
   const [info, setInfo] = useState(null)
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
+  const load = useCallback(async () => {
     if (!address) return
-    async function load() {
-      try {
-        const res = await fetch(`/api/catpool/user/${address}`)
-        if (res.ok) {
-          const data = await res.json()
-          setInfo(data)
-        }
-      } catch (err) {
-        console.error('Failed to load cat pool user info', err)
-      } finally {
-        setLoading(false)
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/catpool/user/${address}`)
+      if (res.ok) {
+        const data = await res.json()
+        setInfo(data)
       }
+    } catch (err) {
+      console.error('Failed to load cat pool user info', err)
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [address])
 
-  return { info, loading }
+  useEffect(() => {
+    load()
+  }, [load])
+
+  return { info, loading, refresh: load }
 }


### PR DESCRIPTION
## Summary
- add `refresh` capability to `useCatPoolUserInfo`
- refresh deposit data when modal actions succeed
- trigger deposit reload in CatPool page
- allow `CatPoolDeposits` to reload when triggered

## Testing
- `npx hardhat test` *(fails: couldn't download compiler due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684bdf61a3b0832eac6a0f22c3509c29