### PR TITLE
Implement Claim entity tracking

### DIFF
--- a/frontend/hooks/useClaims.js
+++ b/frontend/hooks/useClaims.js
@@ -1,6 +1,4 @@
 import { useState, useEffect } from 'react'
-import { riskManager } from '../lib/riskManager'
-import { policyNft } from '../lib/policyNft'
 
 export default function useClaims() {
   const [claims, setClaims] = useState([])
@@ -14,62 +12,33 @@ export default function useClaims() {
 
         const pageSize = 1000
         let skip = 0
-        const events = []
+        const results = []
 
         while (true) {
-          const query = `{ genericEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: desc, where: { eventName: "ClaimProcessed" }) { blockNumber timestamp transactionHash data } }`
+          const query = `{ claims(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: desc) { policyId poolId claimant coverage netPayoutToClaimant claimFee protocolTokenAmountReceived timestamp transactionHash } }`
           const res = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ query }),
           })
           const json = await res.json()
-          const batch = json?.data?.genericEvents || []
-          events.push(...batch)
+          const batch = json?.data?.claims || []
+          results.push(...batch)
           if (batch.length < pageSize) break
           skip += pageSize
         }
 
-        const claimsData = await Promise.all(
-          events.map(async (ev) => {
-            const [policyIdStr, poolIdStr, claimant, netPayoutStr] = ev.data.split(',')
-            const policyId = Number(policyIdStr)
-            const poolId = Number(poolIdStr)
-
-            let coverage = 0n
-            try {
-              const pol = await policyNft.getPolicy(BigInt(policyId))
-              coverage = BigInt(pol.coverage.toString())
-            } catch (err) {
-              console.error(`Failed to fetch policy ${policyId}`, err)
-            }
-
-            let scale = 0n
-            try {
-              const info = await riskManager.getPoolInfo(poolId)
-              scale = BigInt(info.scaleToProtocolToken.toString())
-            } catch (err) {
-              console.error(`Failed to fetch pool ${poolId}`, err)
-            }
-
-            const protocolTokenAmountReceived = (coverage * scale).toString()
-            const netPayout = BigInt(netPayoutStr)
-            const claimFee = coverage > netPayout ? (coverage - netPayout).toString() : '0'
-
-            return {
-              transactionHash: ev.transactionHash,
-              blockNumber: Number(ev.blockNumber),
-              timestamp: Number(ev.timestamp),
-              policyId,
-              poolId,
-              claimant,
-              coverage: coverage.toString(),
-              netPayoutToClaimant: netPayoutStr,
-              claimFee,
-              protocolTokenAmountReceived,
-            }
-          })
-        )
+        const claimsData = results.map((c) => ({
+          transactionHash: c.transactionHash,
+          timestamp: Number(c.timestamp),
+          policyId: Number(c.policyId),
+          poolId: Number(c.poolId),
+          claimant: c.claimant,
+          coverage: c.coverage,
+          netPayoutToClaimant: c.netPayoutToClaimant,
+          claimFee: c.claimFee,
+          protocolTokenAmountReceived: c.protocolTokenAmountReceived,
+        }))
 
         setClaims(claimsData)
       } catch (err) {

--- a/subgraphs/insurance/schema.graphql
+++ b/subgraphs/insurance/schema.graphql
@@ -43,3 +43,16 @@ type PoolUtilizationSnapshot @entity {
   utilizationBps: BigInt!
   premiumRateBps: BigInt!
 }
+
+type Claim @entity {
+  id: ID!
+  policyId: BigInt!
+  poolId: BigInt!
+  claimant: Bytes!
+  coverage: BigInt!
+  netPayoutToClaimant: BigInt!
+  claimFee: BigInt!
+  protocolTokenAmountReceived: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}

--- a/subgraphs/insurance/subgraph.yaml
+++ b/subgraphs/insurance/subgraph.yaml
@@ -23,6 +23,7 @@ dataSources:
         - ContractOwner
         - PoolUtilizationSnapshot
         - PoolUtilizationSnapshot
+        - Claim
       abis:
         - name: RiskManager
           file: ./abis/RiskManager.json
@@ -69,6 +70,7 @@ dataSources:
         - Policy
         - ContractOwner
         - PoolUtilizationSnapshot
+        - Claim
       abis:
         - name: CapitalPool
           file: ./abis/CapitalPool.json
@@ -111,6 +113,7 @@ dataSources:
         - Policy
         - ContractOwner
         - PoolUtilizationSnapshot
+        - Claim
       abis:
         - name: CatInsurancePool
           file: ./abis/CatInsurancePool.json
@@ -155,6 +158,7 @@ dataSources:
         - Policy
         - ContractOwner
         - PoolUtilizationSnapshot
+        - Claim
       abis:
         - name: PolicyNFT
           file: ./abis/PolicyNFT.json

--- a/subgraphs/insurance/tests/claimProcessed.test.ts
+++ b/subgraphs/insurance/tests/claimProcessed.test.ts
@@ -1,0 +1,28 @@
+import { test, assert, clearStore } from 'matchstick-as/assembly/index'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { handleClaimProcessed } from '../src/mapping'
+import { createClaimProcessedEvent } from './utils'
+
+test('handleClaimProcessed creates Claim and GenericEvent', () => {
+  clearStore()
+  const rm = Address.fromString('0x0000000000000000000000000000000000000010')
+  const claimant = Address.fromString('0x0000000000000000000000000000000000000020')
+  const event = createClaimProcessedEvent(
+    BigInt.fromI32(1),
+    BigInt.fromI32(2),
+    claimant,
+    BigInt.fromI32(90),
+    rm
+  )
+  handleClaimProcessed(event)
+  const id = event.transaction.hash.toHex() + '-' + event.logIndex.toString()
+  assert.entityCount('Claim', 1)
+  assert.fieldEquals('Claim', id, 'policyId', '1')
+  assert.fieldEquals('Claim', id, 'poolId', '2')
+  assert.fieldEquals('Claim', id, 'claimant', claimant.toHex())
+  assert.fieldEquals('Claim', id, 'netPayoutToClaimant', '90')
+  assert.fieldEquals('Claim', id, 'coverage', '0')
+  assert.fieldEquals('Claim', id, 'claimFee', '0')
+  assert.fieldEquals('Claim', id, 'protocolTokenAmountReceived', '0')
+  assert.entityCount('GenericEvent', 1)
+})

--- a/subgraphs/insurance/tests/utils.ts
+++ b/subgraphs/insurance/tests/utils.ts
@@ -12,7 +12,7 @@ export function createDepositEvent(user: Address, amount: BigInt, shares: BigInt
   return event
 }
 
-import { PolicyCreated } from '../generated/RiskManager/RiskManager'
+import { PolicyCreated, ClaimProcessed } from '../generated/RiskManager/RiskManager'
 
 export function createPolicyCreatedEvent(
   user: Address,
@@ -73,6 +73,23 @@ export function createWithdrawalRequestedEvent(
   event.parameters.push(new ethereum.EventParam('user', ethereum.Value.fromAddress(user)))
   event.parameters.push(new ethereum.EventParam('sharesToBurn', ethereum.Value.fromUnsignedBigInt(sharesToBurn)))
   event.parameters.push(new ethereum.EventParam('timestamp', ethereum.Value.fromUnsignedBigInt(timestamp)))
+  return event
+}
+
+export function createClaimProcessedEvent(
+  policyId: BigInt,
+  poolId: BigInt,
+  claimant: Address,
+  netPayout: BigInt,
+  contract: Address
+): ClaimProcessed {
+  let event = changetype<ClaimProcessed>(newMockEvent())
+  event.address = contract
+  event.parameters = new Array()
+  event.parameters.push(new ethereum.EventParam('policyId', ethereum.Value.fromUnsignedBigInt(policyId)))
+  event.parameters.push(new ethereum.EventParam('poolId', ethereum.Value.fromUnsignedBigInt(poolId)))
+  event.parameters.push(new ethereum.EventParam('claimant', ethereum.Value.fromAddress(claimant)))
+  event.parameters.push(new ethereum.EventParam('netPayoutToClaimant', ethereum.Value.fromUnsignedBigInt(netPayout)))
   return event
 }
 


### PR DESCRIPTION
## Summary
- define Claim entity for insurance subgraph
- expand mapping to create Claim records
- query Claim entity directly from UI
- add ClaimProcessed test utilities and test case

## Testing
- `npm run codegen` *(passes)*
- `npm run build` *(fails: AssemblyScript compiler crashed)*
- `npm test` *(fails: matchstick not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be790f290832e90d0ab3037cfe4c0