### PR TITLE
Switch to structured subgraph queries

### DIFF
--- a/frontend/app/api/claims/route.ts
+++ b/frontend/app/api/claims/route.ts
@@ -1,6 +1,4 @@
 import { NextResponse } from "next/server";
-import { riskManager } from "../../../lib/riskManager";
-import { policyNft } from "../../../lib/policyNft";
 
 const SUBGRAPH_URL =
   process.env.SUBGRAPH_URL ?? process.env.NEXT_PUBLIC_SUBGRAPH_URL;
@@ -13,15 +11,20 @@ export async function GET() {
 
     const pageSize = 1000;
     let skip = 0;
-    const events: any[] = [];
+    const items: any[] = [];
 
     while (true) {
       const query = `{
-        genericEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: desc, where: { eventName: "ClaimProcessed" }) {
-          blockNumber
+        claims(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: desc) {
+          policyId
+          poolId
+          claimant
+          coverage
+          netPayoutToClaimant
+          claimFee
+          protocolTokenAmountReceived
           timestamp
           transactionHash
-          data
         }
       }`;
 
@@ -32,56 +35,24 @@ export async function GET() {
       });
 
       const json = await response.json();
-      const batch = json?.data?.genericEvents || [];
-      events.push(...batch);
+      const batch = json?.data?.claims || [];
+      items.push(...batch);
 
       if (batch.length < pageSize) break;
       skip += pageSize;
     }
 
-    const claims = await Promise.all(
-      events.map(async (ev: any) => {
-        const [policyIdStr, poolIdStr, claimant, netPayoutStr] = (
-          ev.data as string
-        ).split(",");
-        const policyId = Number(policyIdStr);
-        const poolId = Number(poolIdStr);
-
-        let coverage = 0n;
-        try {
-          const pol = await policyNft.getPolicy(BigInt(policyId));
-          coverage = BigInt(pol.coverage.toString());
-        } catch (err) {
-          console.error(`Failed to fetch policy ${policyId}`, err);
-        }
-
-        let scale = 0n;
-        try {
-          const info = await riskManager.getPoolInfo(poolId);
-          scale = BigInt(info.scaleToProtocolToken.toString());
-        } catch (err) {
-          console.error(`Failed to fetch pool ${poolId}`, err);
-        }
-
-        const protocolTokenAmountReceived = (coverage * scale).toString();
-        const netPayout = BigInt(netPayoutStr);
-        const claimFee =
-          coverage > netPayout ? (coverage - netPayout).toString() : "0";
-
-        return {
-          transactionHash: ev.transactionHash,
-          blockNumber: Number(ev.blockNumber),
-          timestamp: Number(ev.timestamp),
-          policyId,
-          poolId,
-          claimant,
-          coverage: coverage.toString(),
-          netPayoutToClaimant: netPayoutStr,
-          claimFee,
-          protocolTokenAmountReceived,
-        };
-      })
-    );
+    const claims = items.map((c) => ({
+      transactionHash: c.transactionHash,
+      timestamp: Number(c.timestamp),
+      policyId: Number(c.policyId),
+      poolId: Number(c.poolId),
+      claimant: c.claimant,
+      coverage: c.coverage,
+      netPayoutToClaimant: c.netPayoutToClaimant,
+      claimFee: c.claimFee,
+      protocolTokenAmountReceived: c.protocolTokenAmountReceived,
+    }));
 
     return NextResponse.json({ claims });
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- refactor `claims` API to load `Claim` entities instead of GenericEvents
- update analytics API to query `Claim` and `Underwriter` entities

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot use JSX and missing types)*

------
https://chatgpt.com/codex/tasks/task_e_684bf58d76e8832e822f59ffcf8d9285