### PR TITLE
Use typed subgraph events

### DIFF
--- a/frontend/app/api/analytics/route.ts
+++ b/frontend/app/api/analytics/route.ts
@@ -2,25 +2,50 @@ import { NextResponse } from 'next/server';
 
 const SUBGRAPH_URL = process.env.SUBGRAPH_URL ?? process.env.NEXT_PUBLIC_SUBGRAPH_URL;
 
-async function fetchEvents(eventName: string) {
+async function fetchPolicyCreatedEvents() {
   if (!SUBGRAPH_URL) throw new Error('SUBGRAPH_URL not configured');
   const pageSize = 1000;
   let skip = 0;
   const items: any[] = [];
   while (true) {
-    const query = `{
-      genericEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: asc, where: { eventName: "${eventName}" }) {
-        timestamp
-        data
-      }
-    }`;
-    const res = await fetch(SUBGRAPH_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query }),
-    });
+    const query = `{ policyCreatedEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: asc) { policyId poolId user coverage timestamp } }`;
+    const res = await fetch(SUBGRAPH_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ query }) });
     const json = await res.json();
-    const batch = json?.data?.genericEvents || [];
+    const batch = json?.data?.policyCreatedEvents || [];
+    items.push(...batch);
+    if (batch.length < pageSize) break;
+    skip += pageSize;
+  }
+  return items;
+}
+
+async function fetchPolicyLapsedEvents() {
+  if (!SUBGRAPH_URL) throw new Error('SUBGRAPH_URL not configured');
+  const pageSize = 1000;
+  let skip = 0;
+  const items: any[] = [];
+  while (true) {
+    const query = `{ policyLapsedEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: asc) { policyId timestamp } }`;
+    const res = await fetch(SUBGRAPH_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ query }) });
+    const json = await res.json();
+    const batch = json?.data?.policyLapsedEvents || [];
+    items.push(...batch);
+    if (batch.length < pageSize) break;
+    skip += pageSize;
+  }
+  return items;
+}
+
+async function fetchPremiumPaidEvents() {
+  if (!SUBGRAPH_URL) throw new Error('SUBGRAPH_URL not configured');
+  const pageSize = 1000;
+  let skip = 0;
+  const items: any[] = [];
+  while (true) {
+    const query = `{ premiumPaidEvents(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: asc) { policyId amountPaid timestamp } }`;
+    const res = await fetch(SUBGRAPH_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ query }) });
+    const json = await res.json();
+    const batch = json?.data?.premiumPaidEvents || [];
     items.push(...batch);
     if (batch.length < pageSize) break;
     skip += pageSize;
@@ -84,10 +109,10 @@ export async function GET() {
     if (!SUBGRAPH_URL) throw new Error('SUBGRAPH_URL not configured');
 
     const [createdEv, lapsedEv, claims, premiumEv, underwriters] = await Promise.all([
-      fetchEvents('PolicyCreated'),
-      fetchEvents('PolicyLapsed'),
+      fetchPolicyCreatedEvents(),
+      fetchPolicyLapsedEvents(),
       fetchClaims(),
-      fetchEvents('PremiumPaid'),
+      fetchPremiumPaidEvents(),
       fetchUnderwriters(),
     ]);
 
@@ -99,24 +124,21 @@ export async function GET() {
     const underwriterSet = new Set<string>();
     let totalClaimFees = 0n;
     for (const ev of createdEv) {
-      const [user, policyIdStr, poolIdStr, coverageStr] = ev.data.split(',');
-      const cov = BigInt(coverageStr);
-      const pid = Number(policyIdStr);
+      const cov = BigInt(ev.coverage);
+      const pid = Number(ev.policyId);
       coverageMap.set(pid, cov);
-      policyHolderSet.add(user.toLowerCase());
+      policyHolderSet.add(ev.user.toLowerCase());
       events.push({ timestamp: Number(ev.timestamp), type: 'created', policyId: pid, coverage: cov });
     }
     for (const ev of lapsedEv) {
-      const [policyIdStr] = ev.data.split(',');
-      events.push({ timestamp: Number(ev.timestamp), type: 'lapsed', policyId: Number(policyIdStr) });
+      events.push({ timestamp: Number(ev.timestamp), type: 'lapsed', policyId: Number(ev.policyId) });
     }
     for (const c of claims) {
       events.push({ timestamp: Number(c.timestamp), type: 'claim', policyId: Number(c.policyId), coverage: undefined, payout: BigInt(c.netPayoutToClaimant) });
     }
     let totalPremiums = 0n;
     for (const ev of premiumEv) {
-      const [, , amountPaidStr] = ev.data.split(',');
-      totalPremiums += BigInt(amountPaidStr);
+      totalPremiums += BigInt(ev.amountPaid);
     }
 
     for (const u of underwriters) {

--- a/subgraphs/insurance/schema.graphql
+++ b/subgraphs/insurance/schema.graphql
@@ -56,3 +56,31 @@ type Claim @entity {
   timestamp: BigInt!
   transactionHash: Bytes!
 }
+
+type PolicyCreatedEvent @entity {
+  id: ID!
+  policyId: BigInt!
+  poolId: BigInt!
+  user: Bytes!
+  coverage: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type PolicyLapsedEvent @entity {
+  id: ID!
+  policyId: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type PremiumPaidEvent @entity {
+  id: ID!
+  policyId: BigInt!
+  poolId: BigInt!
+  amountPaid: BigInt!
+  catAmount: BigInt!
+  poolIncome: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}

--- a/subgraphs/insurance/subgraph.yaml
+++ b/subgraphs/insurance/subgraph.yaml
@@ -24,6 +24,9 @@ dataSources:
         - PoolUtilizationSnapshot
         - PoolUtilizationSnapshot
         - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
       abis:
         - name: RiskManager
           file: ./abis/RiskManager.json
@@ -71,6 +74,9 @@ dataSources:
         - ContractOwner
         - PoolUtilizationSnapshot
         - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
       abis:
         - name: CapitalPool
           file: ./abis/CapitalPool.json
@@ -114,6 +120,9 @@ dataSources:
         - ContractOwner
         - PoolUtilizationSnapshot
         - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
       abis:
         - name: CatInsurancePool
           file: ./abis/CatInsurancePool.json
@@ -159,6 +168,9 @@ dataSources:
         - ContractOwner
         - PoolUtilizationSnapshot
         - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
       abis:
         - name: PolicyNFT
           file: ./abis/PolicyNFT.json

--- a/subgraphs/insurance/tests/policyCreated.test.ts
+++ b/subgraphs/insurance/tests/policyCreated.test.ts
@@ -3,7 +3,7 @@ import { Address, BigInt } from '@graphprotocol/graph-ts'
 import { handlePolicyCreated } from '../src/mapping'
 import { createPolicyCreatedEvent } from './utils'
 
-test('handlePolicyCreated creates Policy and GenericEvent', () => {
+test('handlePolicyCreated creates Policy and events', () => {
   clearStore()
   let user = Address.fromString('0x0000000000000000000000000000000000000002')
   let event = createPolicyCreatedEvent(
@@ -25,5 +25,12 @@ test('handlePolicyCreated creates Policy and GenericEvent', () => {
     event.transaction.hash.toHex() + '-' + event.logIndex.toString(),
     'eventName',
     'PolicyCreated'
+  )
+  assert.entityCount('PolicyCreatedEvent', 1)
+  assert.fieldEquals(
+    'PolicyCreatedEvent',
+    event.transaction.hash.toHex() + '-' + event.logIndex.toString(),
+    'policyId',
+    '1'
   )
 })

--- a/subgraphs/insurance/tests/policyLapsed.test.ts
+++ b/subgraphs/insurance/tests/policyLapsed.test.ts
@@ -1,0 +1,17 @@
+import { test, assert, clearStore } from 'matchstick-as/assembly/index'
+import { BigInt } from '@graphprotocol/graph-ts'
+import { handlePolicyLapsed } from '../src/mapping'
+import { createPolicyLapsedEvent } from './utils'
+
+test('handlePolicyLapsed creates event', () => {
+  clearStore()
+  let event = createPolicyLapsedEvent(BigInt.fromI32(1))
+  handlePolicyLapsed(event)
+  assert.entityCount('PolicyLapsedEvent', 1)
+  assert.fieldEquals(
+    'PolicyLapsedEvent',
+    event.transaction.hash.toHex() + '-' + event.logIndex.toString(),
+    'policyId',
+    '1'
+  )
+})

--- a/subgraphs/insurance/tests/premiumPaid.test.ts
+++ b/subgraphs/insurance/tests/premiumPaid.test.ts
@@ -1,0 +1,24 @@
+import { test, assert, clearStore } from 'matchstick-as/assembly/index'
+import { BigInt } from '@graphprotocol/graph-ts'
+import { handlePremiumPaid } from '../src/mapping'
+import { createPremiumPaidEvent } from './utils'
+
+test('handlePremiumPaid creates event', () => {
+  clearStore()
+  let event = createPremiumPaidEvent(
+    BigInt.fromI32(1),
+    BigInt.fromI32(2),
+    BigInt.fromI32(50),
+    BigInt.fromI32(5),
+    BigInt.fromI32(45)
+  )
+  handlePremiumPaid(event)
+  assert.entityCount('PremiumPaidEvent', 1)
+  assert.fieldEquals(
+    'PremiumPaidEvent',
+    event.transaction.hash.toHex() + '-' + event.logIndex.toString(),
+    'amountPaid',
+    '50'
+  )
+})
+

--- a/subgraphs/insurance/tests/utils.ts
+++ b/subgraphs/insurance/tests/utils.ts
@@ -93,6 +93,32 @@ export function createClaimProcessedEvent(
   return event
 }
 
+import { PolicyLapsed, PremiumPaid } from '../generated/RiskManager/RiskManager'
+
+export function createPolicyLapsedEvent(policyId: BigInt): PolicyLapsed {
+  let event = changetype<PolicyLapsed>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(new ethereum.EventParam('policyId', ethereum.Value.fromUnsignedBigInt(policyId)))
+  return event
+}
+
+export function createPremiumPaidEvent(
+  policyId: BigInt,
+  poolId: BigInt,
+  amountPaid: BigInt,
+  catAmount: BigInt,
+  poolIncome: BigInt
+): PremiumPaid {
+  let event = changetype<PremiumPaid>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(new ethereum.EventParam('policyId', ethereum.Value.fromUnsignedBigInt(policyId)))
+  event.parameters.push(new ethereum.EventParam('poolId', ethereum.Value.fromUnsignedBigInt(poolId)))
+  event.parameters.push(new ethereum.EventParam('amountPaid', ethereum.Value.fromUnsignedBigInt(amountPaid)))
+  event.parameters.push(new ethereum.EventParam('catAmount', ethereum.Value.fromUnsignedBigInt(catAmount)))
+  event.parameters.push(new ethereum.EventParam('poolIncome', ethereum.Value.fromUnsignedBigInt(poolIncome)))
+  return event
+}
+
 import { OwnershipTransferred as RMOwnershipTransferred } from '../generated/RiskManager/RiskManager'
 
 export function createOwnershipTransferredEvent(


### PR DESCRIPTION
## Summary
- log dedicated `PolicyCreatedEvent`, `PolicyLapsedEvent` and `PremiumPaidEvent` in the subgraph
- expose new entities via API analytics endpoint
- test new event handlers

## Testing
- `npm test` *(fails: matchstick not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf7dca318832e8cb288701c899453