### PR TITLE
Display Cat Pool rewards and APR on dashboard

### DIFF
--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -11,14 +11,18 @@ import CatPoolDeposits from "../components/CatPoolDeposits"
 import useUserPolicies from "../../hooks/useUserPolicies"
 import useUnderwriterDetails from "../../hooks/useUnderwriterDetails"
 import { getCatPoolWithSigner } from "../../lib/catPool"
+import useCatPoolRewards from "../../hooks/useCatPoolRewards"
+import useCatPoolStats from "../../hooks/useCatPoolStats"
+import { ethers } from "ethers"
 
 export default function Dashboard() {
   const { address, isConnected } = useAccount()
   const [displayCurrency, setDisplayCurrency] = useState("native")
-  const [claimTokens, setClaimTokens] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { policies } = useUserPolicies(address)
   const { details } = useUnderwriterDetails(address)
+  const { rewards } = useCatPoolRewards(address)
+  const { stats } = useCatPoolStats()
 
   const hasActiveCoverages = (policies || []).length > 0
   const hasUnderwritingPositions =
@@ -26,14 +30,13 @@ export default function Dashboard() {
   const showPositionsFirst = hasUnderwritingPositions && !hasActiveCoverages
 
   const handleClaim = async () => {
-    if (!claimTokens) return
+    if (!rewards || rewards.length === 0) return
     setIsSubmitting(true)
     try {
       const cp = await getCatPoolWithSigner()
-      const tokens = claimTokens.split(',').map((t) => t.trim()).filter(Boolean)
+      const tokens = rewards.map((r) => r.token)
       const tx = await cp.claimProtocolAssetRewards(tokens)
       await tx.wait()
-      setClaimTokens('')
     } catch (err) {
       console.error('Claim failed', err)
     } finally {
@@ -88,23 +91,31 @@ export default function Dashboard() {
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6 space-y-4">
           <h2 className="text-xl font-semibold mb-4">My Cat Pool Deposits</h2>
           <CatPoolDeposits displayCurrency={displayCurrency} />
-          <div className="pt-4 border-t border-gray-200 dark:border-gray-700 space-y-4">
-            <h3 className="text-lg font-medium">Claim Protocol Asset Rewards</h3>
-            <input
-              type="text"
-              placeholder="Token addresses (comma separated)"
-              value={claimTokens}
-              onChange={(e) => setClaimTokens(e.target.value)}
-              className="w-full p-2 border rounded text-gray-900 dark:text-gray-100 dark:bg-gray-700"
-            />
-            <button
-              onClick={handleClaim}
-              disabled={isSubmitting || !claimTokens}
-              className="w-full py-2 px-4 bg-purple-600 hover:bg-purple-700 text-white rounded disabled:opacity-50"
-            >
-              {isSubmitting ? 'Claiming...' : 'Claim'}
-            </button>
-          </div>
+          {rewards.length > 0 && (
+            <div className="pt-4 border-t border-gray-200 dark:border-gray-700 space-y-4">
+              <h3 className="text-lg font-medium">Claim Protocol Asset Rewards</h3>
+              <div className="text-sm text-gray-500">
+                Current APR: <span className="font-medium text-green-600">{(
+                  Number(ethers.utils.formatUnits(stats.apr || '0', 18)) * 100
+                ).toFixed(2)}%</span>
+              </div>
+              <ul className="text-sm space-y-1">
+                {rewards.map((r) => (
+                  <li key={r.token} className="flex justify-between">
+                    <span>{r.token}</span>
+                    <span>{(Number(r.amount) / 1e18).toFixed(4)}</span>
+                  </li>
+                ))}
+              </ul>
+              <button
+                onClick={handleClaim}
+                disabled={isSubmitting}
+                className="w-full py-2 px-4 bg-purple-600 hover:bg-purple-700 text-white rounded disabled:opacity-50"
+              >
+                {isSubmitting ? 'Claiming...' : 'Claim'}
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/hooks/useCatPoolRewards.js
+++ b/frontend/hooks/useCatPoolRewards.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react'
+import usePools from './usePools'
+
+export default function useCatPoolRewards(address) {
+  const { pools } = usePools()
+  const [rewards, setRewards] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!address) return
+    async function load() {
+      setLoading(true)
+      try {
+        const tokens = [...new Set(pools.map(p => p.protocolTokenToCover))]
+        const results = await Promise.all(
+          tokens.map(async (token) => {
+            try {
+              const res = await fetch(`/api/catpool/rewards/${address}/${token}`)
+              if (!res.ok) return null
+              const data = await res.json()
+              const amt = BigInt(data.claimable || '0')
+              if (amt === 0n) return null
+              return { token, amount: data.claimable }
+            } catch {
+              return null
+            }
+          })
+        )
+        setRewards(results.filter(Boolean))
+      } catch (err) {
+        console.error('Failed to load cat pool rewards', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [address, pools])
+
+  return { rewards, loading }
+}


### PR DESCRIPTION
## Summary
- add `useCatPoolRewards` hook to fetch claimable protocol asset rewards
- show Cat Pool APR and pending rewards on dashboard
- hide claim section when no rewards

## Testing
- `npm run test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_684c18804fd8832ea66b92f4c5e436e9