### PR TITLE
Fix dashboard data flicker

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,7 +3,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // --- Your other settings ---
-  reactStrictMode: true,
+  // Disable React strict mode to prevent double rendering during development,
+  // which caused data flicker on the Dashboard page.
+  reactStrictMode: false,
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- turn off React Strict Mode in the frontend config

## Testing
- `npm test` (fails: Error: no test specified)
- `cd frontend && npm test` *(fails: Cannot find module `vitest`)*

------
https://chatgpt.com/codex/tasks/task_e_684c1def225c832ea8ec19f6c30fd2ad