### PR TITLE
Update governance sidebar width

### DIFF
--- a/frontend/app/staking/page.js
+++ b/frontend/app/staking/page.js
@@ -80,7 +80,7 @@ export default function StakingPage() {
               <SheetTrigger className="ml-2 text-gray-500 hover:text-gray-700">
                 <HelpCircle className="w-4 h-4" />
               </SheetTrigger>
-              <SheetContent side="right" className="w-2/3 sm:max-w-xs">
+              <SheetContent side="right" className="w-1/3 sm:max-w-none text-black dark:text-white">
                 <SheetHeader>
                   <SheetTitle>Stake Voting Token</SheetTitle>
                 </SheetHeader>
@@ -113,7 +113,7 @@ export default function StakingPage() {
               <SheetTrigger className="ml-2 text-gray-500 hover:text-gray-700">
                 <HelpCircle className="w-4 h-4" />
               </SheetTrigger>
-              <SheetContent side="right" className="w-2/3 sm:max-w-xs">
+              <SheetContent side="right" className="w-1/3 sm:max-w-none text-black dark:text-white">
                 <SheetHeader>
                   <SheetTitle>Deposit Bond</SheetTitle>
                 </SheetHeader>


### PR DESCRIPTION
## Summary
- widen the governance info sidebar to one-third of the screen
- make text black in light mode

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails to find vitest)*

------
https://chatgpt.com/codex/tasks/task_e_684c1d7c4fa4832eb9b347610a2afda3