### PR TITLE
Switch staking inputs to modals

### DIFF
--- a/frontend/app/components/BondModal.js
+++ b/frontend/app/components/BondModal.js
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState } from "react"
+import { ethers } from "ethers"
+import { getStakingWithSigner } from "../../lib/staking"
+import Modal from "./Modal"
+
+export default function BondModal({ isOpen, onClose }) {
+  const [poolId, setPoolId] = useState("")
+  const [amount, setAmount] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async () => {
+    if (!amount || poolId === "") return
+    setIsSubmitting(true)
+    try {
+      const staking = await getStakingWithSigner()
+      const tx = await staking.depositBond(poolId, ethers.utils.parseUnits(amount, 18))
+      await tx.wait()
+      setAmount("")
+      setPoolId("")
+      onClose()
+    } catch (err) {
+      console.error("Bond deposit failed", err)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Deposit Bond">
+      <div className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Pool ID
+          </label>
+          <input
+            type="number"
+            value={poolId}
+            onChange={(e) => setPoolId(e.target.value)}
+            placeholder="Pool ID"
+            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Bond Amount
+          </label>
+          <input
+            type="text"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="0.00"
+            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
+          />
+        </div>
+        <button
+          onClick={handleSubmit}
+          disabled={isSubmitting || !amount || poolId === ""}
+          className="w-full py-3 rounded-lg font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
+        >
+          {isSubmitting ? "Processing..." : "Deposit Bond"}
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/app/components/StakeModal.js
+++ b/frontend/app/components/StakeModal.js
@@ -1,0 +1,60 @@
+"use client"
+
+import { useState } from "react"
+import { ethers } from "ethers"
+import { getStakingWithSigner } from "../../lib/staking"
+import Modal from "./Modal"
+
+export default function StakeModal({ isOpen, onClose }) {
+  const [amount, setAmount] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleAmountChange = (e) => {
+    const value = e.target.value
+    if (value === "" || /^\d*\.?\d*$/.test(value)) {
+      setAmount(value)
+    }
+  }
+
+  const handleStake = async () => {
+    if (!amount) return
+    setIsSubmitting(true)
+    try {
+      const staking = await getStakingWithSigner()
+      const tx = await staking.stake(ethers.utils.parseUnits(amount, 18))
+      await tx.wait()
+      setAmount("")
+      onClose()
+    } catch (err) {
+      console.error("Stake failed", err)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Stake Voting Token">
+      <div className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Amount
+          </label>
+          <input
+            type="text"
+            value={amount}
+            onChange={handleAmountChange}
+            placeholder="0.00"
+            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
+          />
+        </div>
+        <button
+          onClick={handleStake}
+          disabled={isSubmitting || !amount}
+          className="w-full py-3 rounded-lg font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isSubmitting ? "Processing..." : "Stake"}
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/app/staking/page.js
+++ b/frontend/app/staking/page.js
@@ -3,8 +3,6 @@
 import { useState } from "react"
 import { useAccount } from "wagmi"
 import { ConnectButton } from "@rainbow-me/rainbowkit"
-import { ethers } from "ethers"
-import { getStakingWithSigner } from "../../lib/staking"
 import ProposalsTable from "../components/ProposalsTable"
 import { HelpCircle } from "lucide-react"
 import {
@@ -14,46 +12,15 @@ import {
   SheetHeader,
   SheetTitle,
 } from "../../components/ui/sheet"
+import StakeModal from "../components/StakeModal"
+import BondModal from "../components/BondModal"
 
 export default function StakingPage() {
   const { isConnected } = useAccount()
-  const [stakeAmount, setStakeAmount] = useState("")
-  const [bondAmount, setBondAmount] = useState("")
-  const [bondPoolId, setBondPoolId] = useState("")
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [stakeOpen, setStakeOpen] = useState(false)
+  const [bondOpen, setBondOpen] = useState(false)
   const [stakeInfoOpen, setStakeInfoOpen] = useState(false)
   const [bondInfoOpen, setBondInfoOpen] = useState(false)
-
-  const handleStake = async () => {
-    if (!stakeAmount) return
-    setIsSubmitting(true)
-    try {
-      const staking = await getStakingWithSigner()
-      const tx = await staking.stake(ethers.utils.parseUnits(stakeAmount, 18))
-      await tx.wait()
-      setStakeAmount("")
-    } catch (err) {
-      console.error("Stake failed", err)
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleBond = async () => {
-    if (!bondAmount || bondPoolId === "") return
-    setIsSubmitting(true)
-    try {
-      const staking = await getStakingWithSigner()
-      const tx = await staking.depositBond(bondPoolId, ethers.utils.parseUnits(bondAmount, 18))
-      await tx.wait()
-      setBondAmount("")
-      setBondPoolId("")
-    } catch (err) {
-      console.error("Bond deposit failed", err)
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
 
 
   if (!isConnected) {
@@ -90,17 +57,9 @@ export default function StakingPage() {
               </SheetContent>
             </Sheet>
           </div>
-          <input
-            type="text"
-            placeholder="Amount"
-            value={stakeAmount}
-            onChange={(e) => setStakeAmount(e.target.value)}
-            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
-          />
           <button
-            onClick={handleStake}
-            disabled={isSubmitting || !stakeAmount}
-            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded disabled:opacity-50"
+            onClick={() => setStakeOpen(true)}
+            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded"
           >
             Stake
           </button>
@@ -123,29 +82,17 @@ export default function StakingPage() {
               </SheetContent>
             </Sheet>
           </div>
-          <input
-            type="number"
-            placeholder="Pool ID"
-            value={bondPoolId}
-            onChange={(e) => setBondPoolId(e.target.value)}
-            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
-          />
-          <input
-            type="text"
-            placeholder="Bond Amount"
-            value={bondAmount}
-            onChange={(e) => setBondAmount(e.target.value)}
-            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
-          />
           <button
-            onClick={handleBond}
-            disabled={isSubmitting || !bondAmount || bondPoolId === ""}
-            className="w-full py-2 px-4 bg-green-600 hover:bg-green-700 text-white rounded disabled:opacity-50"
+            onClick={() => setBondOpen(true)}
+            className="w-full py-2 px-4 bg-green-600 hover:bg-green-700 text-white rounded"
           >
             Deposit Bond
           </button>
         </div>
       </div>
+
+      <StakeModal isOpen={stakeOpen} onClose={() => setStakeOpen(false)} />
+      <BondModal isOpen={bondOpen} onClose={() => setBondOpen(false)} />
 
 
       <div className="mt-8">


### PR DESCRIPTION
## Summary
- add `StakeModal` and `BondModal`
- swap inline inputs on the Governance page for modal buttons

## Testing
- `npm test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_684c28009630832e88f5e9af7d19c50c