### PR TITLE
Update Cat Pool deposit display and link

### DIFF
--- a/frontend/app/components/CatPoolDeposits.js
+++ b/frontend/app/components/CatPoolDeposits.js
@@ -20,14 +20,38 @@ export default function CatPoolDeposits({ displayCurrency, refreshTrigger }) {
   const value = Number(ethers.utils.formatUnits(info.value || "0", 6))
 
   return (
-    <div className="space-y-2">
-      <div className="flex justify-between">
-        <span className="text-sm text-gray-500">CatShare Balance</span>
-        <span className="text-sm font-medium text-gray-900 dark:text-white">{shares.toFixed(4)}</span>
-      </div>
-      <div className="flex justify-between">
-        <span className="text-sm text-gray-500">Current Value</span>
-        <span className="text-sm font-medium text-gray-900 dark:text-white">{formatCurrency(value, "USD", displayCurrency)}</span>
+    <div className="overflow-x-auto -mx-4 sm:mx-0">
+      <div className="inline-block min-w-full align-middle">
+        <div className="overflow-visible shadow-sm ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th scope="col" className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Token
+                </th>
+                <th scope="col" className="px-3 sm:px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Balance
+                </th>
+                <th scope="col" className="px-3 sm:px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Value
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+              <tr>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                  CATLP
+                </td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white text-right">
+                  {shares.toFixed(4)}
+                </td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white text-right">
+                  {formatCurrency(value, "USD", displayCurrency)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   )

--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import Link from "next/link"
 import { ConnectButton } from '@rainbow-me/rainbowkit'
 import CurrencyToggle from "../components/CurrencyToggle"
 import ActiveCoverages from "../components/ActiveCoverages"
@@ -89,7 +90,15 @@ export default function Dashboard() {
         </div>
 
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6 space-y-4">
-          <h2 className="text-xl font-semibold mb-4">My Cat Pool Deposits</h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">My Cat Pool Deposits</h2>
+            <Link
+              href="/catpool"
+              className="py-1 px-3 bg-gray-100 dark:bg-gray-600 hover:bg-gray-200 dark:hover:bg-gray-500 text-gray-800 dark:text-gray-200 text-sm font-medium rounded-md transition-colors"
+            >
+              Manage
+            </Link>
+          </div>
           <CatPoolDeposits displayCurrency={displayCurrency} />
           {rewards.length > 0 && (
             <div className="pt-4 border-t border-gray-200 dark:border-gray-700 space-y-4">


### PR DESCRIPTION
## Summary
- add Manage link on dashboard deposits card
- display Cat Pool deposits in table format

## Testing
- `npm test` *(fails: Cannot find module 'vitest.mjs')*
- `npm test` in repo root *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c285cdce0832eaf755151c3dae184