### PR TITLE
Add dropdown selectors and balance info

### DIFF
--- a/frontend/app/components/BondModal.js
+++ b/frontend/app/components/BondModal.js
@@ -1,24 +1,48 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { ethers } from "ethers"
 import { getStakingWithSigner } from "../../lib/staking"
 import Modal from "./Modal"
+import usePools from "../../hooks/usePools"
+import useTokenList from "../../hooks/useTokenList"
+import { getProtocolName, getTokenName } from "../config/tokenNameMap"
 
 export default function BondModal({ isOpen, onClose }) {
-  const [poolId, setPoolId] = useState("")
+  const { pools } = usePools()
+  const tokens = useTokenList(pools)
+
+  const [selectedToken, setSelectedToken] = useState("")
+  const [selectedProtocol, setSelectedProtocol] = useState("")
   const [amount, setAmount] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  useEffect(() => {
+    if (!selectedToken && tokens && tokens.length > 0) {
+      setSelectedToken(tokens[0].address)
+    }
+  }, [tokens, selectedToken])
+
+  useEffect(() => {
+    if (!selectedProtocol && pools && pools.length > 0) {
+      setSelectedProtocol(String(pools[0].id))
+    }
+  }, [pools, selectedProtocol])
+
   const handleSubmit = async () => {
-    if (!amount || poolId === "") return
+    if (!amount || !selectedProtocol || !selectedToken) return
+    const pool = pools.find(
+      (p) =>
+        String(p.id) === selectedProtocol &&
+        p.protocolTokenToCover.toLowerCase() === selectedToken.toLowerCase(),
+    )
+    if (!pool) return
     setIsSubmitting(true)
     try {
       const staking = await getStakingWithSigner()
-      const tx = await staking.depositBond(poolId, ethers.utils.parseUnits(amount, 18))
+      const tx = await staking.depositBond(pool.id, ethers.utils.parseUnits(amount, 18))
       await tx.wait()
       setAmount("")
-      setPoolId("")
       onClose()
     } catch (err) {
       console.error("Bond deposit failed", err)
@@ -32,15 +56,35 @@ export default function BondModal({ isOpen, onClose }) {
       <div className="space-y-6">
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Pool ID
+            Asset
           </label>
-          <input
-            type="number"
-            value={poolId}
-            onChange={(e) => setPoolId(e.target.value)}
-            placeholder="Pool ID"
+          <select
             className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
-          />
+            value={selectedToken}
+            onChange={(e) => setSelectedToken(e.target.value)}
+          >
+            {tokens.map((t) => (
+              <option key={t.address} value={t.address}>
+                {getTokenName(t.address)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Protocol
+          </label>
+          <select
+            className="w-full p-2 border rounded-md dark:bg-gray-700 dark:text-gray-100"
+            value={selectedProtocol}
+            onChange={(e) => setSelectedProtocol(e.target.value)}
+          >
+            {pools.map((p) => (
+              <option key={p.id} value={p.id}>
+                {getProtocolName(p.id)}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -56,7 +100,7 @@ export default function BondModal({ isOpen, onClose }) {
         </div>
         <button
           onClick={handleSubmit}
-          disabled={isSubmitting || !amount || poolId === ""}
+          disabled={isSubmitting || !amount}
           className="w-full py-3 rounded-lg font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
         >
           {isSubmitting ? "Processing..." : "Deposit Bond"}


### PR DESCRIPTION
## Summary
- update Deposit Bond modal to pick asset and protocol from dropdowns
- enhance Stake modal to show token balance and max deposit option

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: vitest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2d87c198832ea6f01a75fce971f0