### PR TITLE
Add deployment selection to API routes

### DIFF
--- a/frontend/app/api/adapters/route.ts
+++ b/frontend/app/api/adapters/route.ts
@@ -1,19 +1,26 @@
 import { NextResponse } from 'next/server';
-import { capitalPool } from '../../../lib/capitalPool';
+import { getCapitalPool } from '../../../lib/capitalPool';
 import { provider } from '../../../lib/provider';
 import { ethers } from 'ethers';
+import deployments from '../../config/deployments';
 
 const ADAPTER_ABI = [
   'function currentApr() view returns (uint256)',
   'function asset() view returns (address)',
 ];
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    const url = new URL(req.url);
+    const depName = url.searchParams.get('deployment');
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+
+    const cp = getCapitalPool(dep.capitalPool);
+
     const adapters: { address: string; apr: string; asset: string }[] = [];
     for (let i = 0; i < 20; i++) {
       try {
-        const addr = await (capitalPool as any).activeYieldAdapterAddresses(i);
+        const addr = await (cp as any).activeYieldAdapterAddresses(i);
         const contract = new ethers.Contract(addr, ADAPTER_ABI, provider);
         let apr = '0';
         let asset = ethers.constants.AddressZero;

--- a/frontend/app/api/catpool/apr/route.ts
+++ b/frontend/app/api/catpool/apr/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from 'next/server';
-import { catPool, provider } from '../../../../lib/catPool';
+import { provider } from '../../../../lib/provider';
 import { ethers } from 'ethers';
+import CatPoolAbi from '../../../../abi/CatInsurancePool.json';
+import deployments from '../../../config/deployments';
 
 const APR_ABI = ['function currentApr() view returns (uint256)'];
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
-    const adapterAddr = await catPool.adapter();
+    const url = new URL(req.url);
+    const depName = url.searchParams.get('deployment');
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const adapterAddr = await cp.adapter();
     let apr = '0';
     if (adapterAddr !== ethers.constants.AddressZero) {
       const contract = new ethers.Contract(adapterAddr, APR_ABI, provider);

--- a/frontend/app/api/catpool/claim/route.ts
+++ b/frontend/app/api/catpool/claim/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getCatPoolWriter } from '../../../../lib/catPool';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { tokens } = await req.json();
-    const cp = getCatPoolWriter();
+    const { tokens, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCatPoolWriter(dep.catPool);
     const tx = await cp.claimProtocolAssetRewards(tokens);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/catpool/deposit/route.ts
+++ b/frontend/app/api/catpool/deposit/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getCatPoolWriter } from '../../../../lib/catPool';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { amount } = await req.json();
-    const cp = getCatPoolWriter();
+    const { amount, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCatPoolWriter(dep.catPool);
     const tx = await cp.depositLiquidity(amount);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/catpool/liquidusdc/route.ts
+++ b/frontend/app/api/catpool/liquidusdc/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from 'next/server';
-import { catPool } from '../../../../lib/catPool';
+import { provider } from '../../../../lib/provider';
+import CatPoolAbi from '../../../../abi/CatInsurancePool.json';
+import deployments from '../../../config/deployments';
+import { ethers } from 'ethers';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
-    const amount = await catPool.liquidUsdc();
+    const url = new URL(req.url);
+    const depName = url.searchParams.get('deployment');
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const amount = await cp.liquidUsdc();
     return NextResponse.json({ liquidUsdc: amount.toString() });
   } catch (err: any) {
     return NextResponse.json({ error: err.message }, { status: 500 });

--- a/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
+++ b/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from 'next/server';
-import { catPool } from '../../../../../../lib/catPool';
+import { provider } from '../../../../../../lib/provider';
+import CatPoolAbi from '../../../../../../abi/CatInsurancePool.json';
+import deployments from '../../../../../config/deployments';
+import { ethers } from 'ethers';
 
-export async function GET(_req: Request, { params }: { params: { address: string; token: string } }) {
+export async function GET(req: Request, { params }: { params: { address: string; token: string } }) {
   try {
-    const amount = await catPool.calculateClaimableProtocolAssetRewards(params.address, params.token);
+    const url = new URL(req.url);
+    const depName = url.searchParams.get('deployment');
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const amount = await cp.calculateClaimableProtocolAssetRewards(params.address, params.token);
     return NextResponse.json({ address: params.address, token: params.token, claimable: amount.toString() });
   } catch (err: any) {
     return NextResponse.json({ error: err.message }, { status: 500 });

--- a/frontend/app/api/catpool/withdraw/route.ts
+++ b/frontend/app/api/catpool/withdraw/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getCatPoolWriter } from '../../../../lib/catPool';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { shares } = await req.json();
-    const cp = getCatPoolWriter();
+    const { shares, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCatPoolWriter(dep.catPool);
     const tx = await cp.withdrawLiquidity(shares);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/claim/route.ts
+++ b/frontend/app/api/coverpool/claim/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getRiskManagerWriter } from '../../../../lib/riskManager';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { policyId, proof } = await req.json();
-    const rm = getRiskManagerWriter();
+    const { policyId, proof, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const rm = getRiskManagerWriter(dep.riskManager);
     const tx = await rm.processClaim(policyId, proof);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/deposit/route.ts
+++ b/frontend/app/api/coverpool/deposit/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server';
 import { getCapitalPoolWriter } from '../../../../lib/capitalPool';
 import { getRiskManagerWriter } from '../../../../lib/riskManager';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { amount, yieldChoice, poolIds } = await req.json();
-    const cp = getCapitalPoolWriter();
-    const rm = getRiskManagerWriter();
+    const { amount, yieldChoice, poolIds, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCapitalPoolWriter(dep.capitalPool);
+    const rm = getRiskManagerWriter(dep.riskManager);
     const tx = await cp.deposit(amount, yieldChoice);
     await tx.wait();
     if (poolIds && poolIds.length > 0) {

--- a/frontend/app/api/coverpool/execute-withdrawal/route.ts
+++ b/frontend/app/api/coverpool/execute-withdrawal/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server';
 import { getCapitalPoolWriter } from '../../../../lib/capitalPool';
+import deployments from '../../../config/deployments';
 
-export async function POST() {
+export async function POST(req: Request) {
   try {
-    const cp = getCapitalPoolWriter();
+    const url = new URL(req.url);
+    const depName = url.searchParams.get('deployment');
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCapitalPoolWriter(dep.capitalPool);
     const tx = await cp.executeWithdrawal();
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/purchase/route.ts
+++ b/frontend/app/api/coverpool/purchase/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getRiskManagerWriter } from '../../../../lib/riskManager';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { poolId, coverageAmount, initialPremiumDeposit } = await req.json();
-    const rm = getRiskManagerWriter();
+    const { poolId, coverageAmount, initialPremiumDeposit, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const rm = getRiskManagerWriter(dep.riskManager);
     const tx = await rm.purchaseCover(poolId, coverageAmount, initialPremiumDeposit);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/request-withdrawal/route.ts
+++ b/frontend/app/api/coverpool/request-withdrawal/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getCapitalPoolWriter } from '../../../../lib/capitalPool';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { shares } = await req.json();
-    const cp = getCapitalPoolWriter();
+    const { shares, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCapitalPoolWriter(dep.capitalPool);
     const tx = await cp.requestWithdrawal(shares);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/settle/route.ts
+++ b/frontend/app/api/coverpool/settle/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getRiskManagerWriter } from '../../../../lib/riskManager';
+import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
-    const { policyId } = await req.json();
-    const rm = getRiskManagerWriter();
+    const { policyId, deployment: depName } = await req.json();
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const rm = getRiskManagerWriter(dep.riskManager);
     const tx = await rm.settlePremium(policyId);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -1,13 +1,20 @@
 import { NextResponse } from 'next/server'
-import { riskManager } from '../../../lib/riskManager'
-import { capitalPool } from '../../../lib/capitalPool'
+import { getRiskManager } from '../../../lib/riskManager'
+import { getCapitalPool } from '../../../lib/capitalPool'
+import deployments from '../../config/deployments'
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    const url = new URL(req.url)
+    const depName = url.searchParams.get('deployment')
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
+    const rm = getRiskManager(dep.riskManager)
+    const cp = getCapitalPool(dep.capitalPool)
+
     const [cooldown, claimFee, notice] = await Promise.all([
-      (riskManager as any).COVER_COOLDOWN_PERIOD(),
-      (riskManager as any).CLAIM_FEE_BPS(),
-      (capitalPool as any).UNDERWRITER_NOTICE_PERIOD(),
+      (rm as any).COVER_COOLDOWN_PERIOD(),
+      (rm as any).CLAIM_FEE_BPS(),
+      (cp as any).UNDERWRITER_NOTICE_PERIOD(),
     ])
     return NextResponse.json({
       coverCooldownPeriod: cooldown.toString(),


### PR DESCRIPTION
## Summary
- support selecting deployment for adapters, catpool, coverpool, and reserve-config routes
- default to the first deployment when none specified

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: Cannot find module 'vitest/vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_684c2dfbcca4832ea50b3eadbb886638