### PR TITLE
Support per-deployment providers

### DIFF
--- a/frontend/app/api/adapters/route.ts
+++ b/frontend/app/api/adapters/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { capitalPool } from '../../../lib/capitalPool';
-import { provider } from '../../../lib/provider';
+import { getProvider } from '../../../lib/provider';
 import { ethers } from 'ethers';
 
 const ADAPTER_ABI = [
@@ -11,6 +11,7 @@ const ADAPTER_ABI = [
 export async function GET() {
   try {
     const adapters: { address: string; apr: string; asset: string }[] = [];
+    const provider = getProvider();
     for (let i = 0; i < 20; i++) {
       try {
         const addr = await (capitalPool as any).activeYieldAdapterAddresses(i);

--- a/frontend/app/api/catpool/apr/route.ts
+++ b/frontend/app/api/catpool/apr/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { catPool, provider } from '../../../../lib/catPool';
+import { catPool } from '../../../../lib/catPool';
+import { getProvider } from '../../../../lib/provider';
 import { ethers } from 'ethers';
 
 const APR_ABI = ['function currentApr() view returns (uint256)'];
@@ -9,6 +10,7 @@ export async function GET() {
     const adapterAddr = await catPool.adapter();
     let apr = '0';
     if (adapterAddr !== ethers.constants.AddressZero) {
+      const provider = getProvider();
       const contract = new ethers.Contract(adapterAddr, APR_ABI, provider);
       try {
         const res = await contract.currentApr();

--- a/frontend/app/api/catpool/user/[address]/route.ts
+++ b/frontend/app/api/catpool/user/[address]/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
-import { catPool, provider } from '../../../../../lib/catPool';
+import { catPool } from '../../../../../lib/catPool';
+import { getProvider } from '../../../../../lib/provider';
 import ERC20 from '../../../../../abi/ERC20.json';
 import { ethers } from 'ethers';
 
 export async function GET(_req: Request, { params }: { params: { address: string } }) {
   try {
     const addr = params.address.toLowerCase();
+    const provider = getProvider();
     const catShareAddr = await catPool.catShareToken();
     const token = new ethers.Contract(catShareAddr, ERC20, provider);
     const [balance, totalSupply, liquid] = await Promise.all([

--- a/frontend/app/api/policies/user/[address]/route.ts
+++ b/frontend/app/api/policies/user/[address]/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { policyNft } from '@/lib/policyNft'
 import { getRiskManager } from '@/lib/riskManager'
+import { getProvider } from '@/lib/provider'
 import deployments from '../../../../config/deployments'
 
 export async function GET(
@@ -23,7 +24,7 @@ export async function GET(
           const p = await policyNft.getPolicy(i)
           let deployment: string | null = null
           for (const dep of deployments) {
-            const rm = getRiskManager(dep.riskManager)
+            const rm = getRiskManager(dep.riskManager, getProvider(dep.name))
             try {
               await rm.getPoolInfo(p.poolId)
               deployment = dep.name

--- a/frontend/app/api/pools/[id]/route.ts
+++ b/frontend/app/api/pools/[id]/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server';
 // import your provider and contract instances
 import { getRiskManager } from '../../../../lib/riskManager';
+import { getProvider } from '../../../../lib/provider';
 import deployments from '../../../config/deployments';
 
 export async function GET(
@@ -15,7 +16,7 @@ export async function GET(
   }
 
   for (const dep of deployments) {
-    const riskManager = getRiskManager(dep.riskManager);
+    const riskManager = getRiskManager(dep.riskManager, getProvider(dep.name));
     try {
       const poolInfo = await riskManager.getPoolInfo(idNum);
       return NextResponse.json({ id: idNum, deployment: dep.name, poolInfo });

--- a/frontend/app/api/pools/list/route.ts
+++ b/frontend/app/api/pools/list/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { getRiskManager } from '../../../../lib/riskManager';
 import { getPriceOracle } from '../../../../lib/priceOracle';
+import { getProvider } from '../../../../lib/provider';
 import deployments from '../../../config/deployments';
 import { ethers } from 'ethers';
 
@@ -103,8 +104,9 @@ function calcPremiumRateBps(pool: any): bigint {
 export async function GET() {
   const allPools: any[] = []
   for (const dep of deployments) {
-    const riskManager = getRiskManager(dep.riskManager)
-    const priceOracle = getPriceOracle(dep.priceOracle)
+    const provider = getProvider(dep.name)
+    const riskManager = getRiskManager(dep.riskManager, provider)
+    const priceOracle = getPriceOracle(dep.priceOracle, provider)
     try {
     /* 1️⃣ How many pools exist? */
     let count = 0n;

--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { getCapitalPool } from '@/lib/capitalPool'
 import { getRiskManager } from '@/lib/riskManager'
+import { getProvider } from '@/lib/provider'
 import deployments from '../../../config/deployments'
 
 export async function GET(
@@ -15,8 +16,9 @@ export async function GET(
     const details: any[] = []
 
     for (const dep of deployments) {
-      const cp = getCapitalPool(dep.capitalPool)
-      const rm = getRiskManager(dep.riskManager)
+      const provider = getProvider(dep.name)
+      const cp = getCapitalPool(dep.capitalPool, provider)
+      const rm = getRiskManager(dep.riskManager, provider)
 
       try {
         const account = await cp.getUnderwriterAccount(addr)

--- a/frontend/lib/capitalPool.ts
+++ b/frontend/lib/capitalPool.ts
@@ -1,14 +1,17 @@
-import { ethers } from 'ethers';
-import CapitalPool from '../abi/CapitalPool.json';
-import { provider } from './provider';
+import { ethers } from 'ethers'
+import CapitalPool from '../abi/CapitalPool.json'
+import { getProvider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_CAPITAL_POOL_ADDRESS as string;
 
-export function getCapitalPool(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, CapitalPool, provider);
+export function getCapitalPool(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  return new ethers.Contract(address, CapitalPool, provider)
 }
 
-export const capitalPool = getCapitalPool();
+export const capitalPool = getCapitalPool()
 
 export async function getCapitalPoolWithSigner(address: string = DEFAULT_ADDRESS) {
   if (typeof window === 'undefined' || !window.ethereum)
@@ -20,7 +23,10 @@ export async function getCapitalPoolWithSigner(address: string = DEFAULT_ADDRESS
   return new ethers.Contract(address, CapitalPool, signer);
 }
 
-export function getCapitalPoolWriter(address: string = DEFAULT_ADDRESS) {
+export function getCapitalPoolWriter(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
   const signer = new ethers.Wallet(pk, provider);
@@ -28,13 +34,23 @@ export function getCapitalPoolWriter(address: string = DEFAULT_ADDRESS) {
 }
 
 // Helper to query the underlying ERC20 asset used by the capital pool
-export async function getUnderlyingAssetAddress(address: string = DEFAULT_ADDRESS) {
-  const cp = new ethers.Contract(address, ['function underlyingAsset() view returns (address)'], provider);
+export async function getUnderlyingAssetAddress(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  const cp = new ethers.Contract(
+    address,
+    ['function underlyingAsset() view returns (address)'],
+    provider,
+  )
   return await cp.underlyingAsset();
 }
 
-export async function getUnderlyingAssetDecimals(address: string = DEFAULT_ADDRESS) {
-  const assetAddr = await getUnderlyingAssetAddress(address);
+export async function getUnderlyingAssetDecimals(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  const assetAddr = await getUnderlyingAssetAddress(address, provider)
   const token = new ethers.Contract(
     assetAddr,
     ['function decimals() view returns (uint8)'],
@@ -43,8 +59,12 @@ export async function getUnderlyingAssetDecimals(address: string = DEFAULT_ADDRE
   return await token.decimals();
 }
 
-export async function getUnderlyingAssetBalance(address: string, poolAddr: string = DEFAULT_ADDRESS) {
-  const assetAddr = await getUnderlyingAssetAddress(poolAddr);
+export async function getUnderlyingAssetBalance(
+  address: string,
+  poolAddr: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  const assetAddr = await getUnderlyingAssetAddress(poolAddr, provider)
   const token = new ethers.Contract(
     assetAddr,
     ['function balanceOf(address) view returns (uint256)'],

--- a/frontend/lib/catPool.ts
+++ b/frontend/lib/catPool.ts
@@ -1,59 +1,55 @@
-import { ethers } from 'ethers';
-import CatPool from '../abi/CatInsurancePool.json';
-// lib/provider.ts (or wherever you construct it)
+import { ethers } from 'ethers'
+import CatPool from '../abi/CatInsurancePool.json'
+import { getProvider } from './provider'
 
+const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
+export function getCatPool(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  return new ethers.Contract(address, CatPool, provider)
+}
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
+export const catPool = getCatPool()
 
-export const catPool = new ethers.Contract(
-  process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
-  CatPool,
-  provider
-);
-
-export function getCatPoolWriter() {
+export function getCatPoolWriter(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
   const signer = new ethers.Wallet(pk, provider);
-  return new ethers.Contract(process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string, CatPool, signer);
+  return new ethers.Contract(address, CatPool, signer);
 }
 
-export async function getCatPoolWithSigner() {
+export async function getCatPoolWithSigner(address: string = DEFAULT_ADDRESS) {
   if (typeof window === 'undefined' || !window.ethereum)
     throw new Error('Wallet not found');
 
   const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
   const signer = await browserProvider.getSigner();
 
-  return new ethers.Contract(
-    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
-    CatPool,
-    signer
-  );
+  return new ethers.Contract(address, CatPool, signer);
 }
 
-export async function getUsdcAddress() {
+export async function getUsdcAddress(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
   const cp = new ethers.Contract(
-    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
+    address,
     ['function usdc() view returns (address)'],
     provider,
-  );
+  )
   return await cp.usdc();
 }
 
-export async function getUsdcDecimals() {
-  const addr = await getUsdcAddress();
+export async function getUsdcDecimals(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  const addr = await getUsdcAddress(address, provider)
   const token = new ethers.Contract(
     addr,
     ['function decimals() view returns (uint8)'],
@@ -62,17 +58,23 @@ export async function getUsdcDecimals() {
   return await token.decimals();
 }
 
-export async function getCatShareAddress() {
+export async function getCatShareAddress(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
   const cp = new ethers.Contract(
-    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
+    address,
     ['function catShareToken() view returns (address)'],
     provider,
-  );
+  )
   return await cp.catShareToken();
 }
 
-export async function getCatShareDecimals() {
-  const addr = await getCatShareAddress();
+export async function getCatShareDecimals(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  const addr = await getCatShareAddress(address, provider)
   const token = new ethers.Contract(
     addr,
     ['function decimals() view returns (uint8)'],

--- a/frontend/lib/committee.ts
+++ b/frontend/lib/committee.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import Committee from '../abi/Committee.json'
-import { provider } from './provider'
+import { getProvider } from './provider'
 
 const ADDRESS = process.env.NEXT_PUBLIC_COMMITTEE_ADDRESS as string
 
@@ -9,7 +9,7 @@ if (!ADDRESS) {
   throw new Error('NEXT_PUBLIC_COMMITTEE_ADDRESS not set')
 }
 
-export const committee = new ethers.Contract(ADDRESS, Committee, provider)
+export const committee = new ethers.Contract(ADDRESS, Committee, getProvider())
 
 export async function getCommitteeWithSigner() {
   if (typeof window === 'undefined' || !window.ethereum)

--- a/frontend/lib/erc20.ts
+++ b/frontend/lib/erc20.ts
@@ -1,12 +1,9 @@
 import { ethers } from 'ethers'
 import ERC20 from '../abi/ERC20.json'
-import { provider } from './provider'
-
-const rpc = process.env.NEXT_PUBLIC_RPC_URL;
-console.log('RPC URL:', rpc);
+import { getProvider } from './provider'
 
 
-export function getERC20(address: string) {
+export function getERC20(address: string, provider = getProvider()) {
   return new ethers.Contract(address, ERC20, provider)
 }
 
@@ -18,27 +15,30 @@ export async function getERC20WithSigner(address: string) {
   return new ethers.Contract(address, ERC20, signer)
 }
 
-export async function getTokenSymbol(address: string) {
+export async function getTokenSymbol(address: string, provider = getProvider()) {
   try {
-    const c = getERC20(address)
+    const c = getERC20(address, provider)
     return await c.symbol()
   } catch {
     return ''
   }
 }
 
-export async function getTokenName(address: string) {
+export async function getTokenName(address: string, provider = getProvider()) {
   try {
-    const c = getERC20(address)
+    const c = getERC20(address, provider)
     return await c.name()
   } catch {
     return ''
   }
 }
 
-export async function getTokenDecimals(address: string) {
+export async function getTokenDecimals(
+  address: string,
+  provider = getProvider(),
+) {
   try {
-    const c = getERC20(address)
+    const c = getERC20(address, provider)
     return await c.decimals()
   } catch {
     return 18

--- a/frontend/lib/policyNft.ts
+++ b/frontend/lib/policyNft.ts
@@ -1,41 +1,25 @@
-import { ethers } from 'ethers';
-import PolicyNFT from '../abi/PolicyNFT.json';
+import { ethers } from 'ethers'
+import PolicyNFT from '../abi/PolicyNFT.json'
+import { getProvider } from './provider'
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
+const DEFAULT_ADDRESS =
+  process.env.NEXT_PUBLIC_POLICY_NFT_ADDRESS ?? process.env.POLICY_NFT_ADDRESS
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
-
-const rpc = process.env.NEXT_PUBLIC_RPC_URL;
-console.log('RPC URL:', rpc);
-
-
-const READ_ADDRESS =
-  process.env.NEXT_PUBLIC_POLICY_NFT_ADDRESS ??
-  process.env.POLICY_NFT_ADDRESS;
-
-if (!READ_ADDRESS) {
-  console.error('❌  POLICY_NFT_ADDRESS env var is missing');
-  throw new Error('POLICY_NFT_ADDRESS not set');
+export function getPolicyNft(
+  address: string = DEFAULT_ADDRESS as string,
+  provider = getProvider(),
+) {
+  return new ethers.Contract(address, PolicyNFT, provider)
 }
 
-export const policyNft = new ethers.Contract(
-  READ_ADDRESS as string,
-  PolicyNFT,
-  provider,
-);
+export const policyNft = getPolicyNft()
 
-export function getPolicyNftWriter() {
+export function getPolicyNftWriter(
+  address: string = DEFAULT_ADDRESS as string,
+  provider = getProvider(),
+) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
   const signer = new ethers.Wallet(pk, provider);
-  return new ethers.Contract(process.env.POLICY_NFT_ADDRESS as string, PolicyNFT, signer);
+  return new ethers.Contract(address, PolicyNFT, signer);
 }

--- a/frontend/lib/priceOracle.ts
+++ b/frontend/lib/priceOracle.ts
@@ -1,14 +1,17 @@
 import { ethers } from 'ethers'
 import PriceOracle from '../abi/PriceOracle.json'
-import { provider } from './provider'
+import { getProvider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_PRICE_ORACLE_ADDRESS as string;
 
-export function getPriceOracle(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, PriceOracle, provider);
+export function getPriceOracle(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  return new ethers.Contract(address, PriceOracle, provider)
 }
 
-export const priceOracle = getPriceOracle();
+export const priceOracle = getPriceOracle()
 
 export async function getLatestUsdPrice(token: string, oracle = priceOracle) {
   const [price, decimals] = await oracle.getLatestUsdPrice(token)

--- a/frontend/lib/provider.ts
+++ b/frontend/lib/provider.ts
@@ -1,14 +1,41 @@
-import { ethers } from 'ethers';
+import { ethers } from 'ethers'
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??     // dev in the browser
-  process.env.RPC_URL ??                 // server / CI
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';  // fallback
+type Deployment = {
+  name: string
+  rpcUrl?: string
+  chainId?: number
+}
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
+let deployments: Deployment[] = []
+const raw = process.env.NEXT_PUBLIC_DEPLOYMENTS
+if (raw) {
+  try {
+    deployments = JSON.parse(raw)
+  } catch (err) {
+    console.error('Failed to parse NEXT_PUBLIC_DEPLOYMENTS', err)
+  }
+}
+
+export function getProvider(deploymentName?: string) {
+  const dep = deploymentName
+    ? deployments.find((d) => d.name === deploymentName)
+    : undefined
+
+  const url =
+    dep?.rpcUrl ??
+    process.env.NEXT_PUBLIC_RPC_URL ??
+    process.env.RPC_URL ??
+    'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe'
+
+  const chainId = Number(
+    dep?.chainId ??
+      process.env.NEXT_PUBLIC_CHAIN_ID ??
+      process.env.CHAIN_ID ??
+      8453,
+  )
+
+  return new ethers.providers.StaticJsonRpcProvider(url, {
+    name: dep?.name ?? 'base',
+    chainId,
+  })
+}

--- a/frontend/lib/riskManager.ts
+++ b/frontend/lib/riskManager.ts
@@ -1,7 +1,7 @@
 // lib/riskManager.ts
-import { ethers } from 'ethers';
-import RiskManager from '../abi/RiskManager.json';
-import { provider } from './provider';
+import { ethers } from 'ethers'
+import RiskManager from '../abi/RiskManager.json'
+import { getProvider } from './provider'
 
 /* ───────────────────────────────
    Validate & create read-only contract
@@ -14,11 +14,14 @@ if (!DEFAULT_ADDRESS) {
   throw new Error('NEXT_PUBLIC_RISK_MANAGER_ADDRESS not set');
 }
 
-export function getRiskManager(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, RiskManager, provider);
+export function getRiskManager(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
+  return new ethers.Contract(address, RiskManager, provider)
 }
 
-export const riskManager = getRiskManager();
+export const riskManager = getRiskManager()
 
 /* ───────────────────────────────
    Browser signer (MetaMask, Coinbase Wallet…)
@@ -51,14 +54,17 @@ export async function getRiskManagerWithSigner(address: string = DEFAULT_ADDRESS
    Server/CI writer (private-key signer)
 ────────────────────────────────── */
 
-export function getRiskManagerWriter(address: string = DEFAULT_ADDRESS) {
+export function getRiskManagerWriter(
+  address: string = DEFAULT_ADDRESS,
+  provider = getProvider(),
+) {
   try {
     const pk = process.env.PRIVATE_KEY;
     if (!pk) {
       throw new Error('PRIVATE_KEY env var not set');
     }
 
-    const signer = new ethers.Wallet(pk, provider);
+    const signer = new ethers.Wallet(pk, provider)
     console.log('✅  Writer signer loaded – address:', signer.address);
 
     return new ethers.Contract(address, RiskManager, signer);

--- a/frontend/lib/staking.ts
+++ b/frontend/lib/staking.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import Staking from '../abi/Staking.json'
-import { provider } from './provider'
+import { getProvider } from './provider'
 
 // Validate presence of the staking contract address
 const ADDRESS = process.env.NEXT_PUBLIC_STAKING_ADDRESS as string
@@ -10,7 +10,7 @@ if (!ADDRESS) {
   throw new Error('NEXT_PUBLIC_STAKING_ADDRESS not set')
 }
 
-export const staking = new ethers.Contract(ADDRESS, Staking, provider)
+export const staking = new ethers.Contract(ADDRESS, Staking, getProvider())
 
 export async function getStakingWithSigner() {
   if (typeof window === 'undefined' || !window.ethereum)


### PR DESCRIPTION
## Summary
- add `getProvider` helper that selects RPC URL and chain ID by deployment name
- update contract wrappers to accept a provider or use `getProvider`
- use the correct provider in API routes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Cannot find module vitest.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_684c2dfea31c832eaeeaa580f107122d