### PR TITLE
Support multi-deployment modals

### DIFF
--- a/frontend/app/components/ActiveCoverages.js
+++ b/frontend/app/components/ActiveCoverages.js
@@ -76,6 +76,7 @@ export default function ActiveCoverages({ displayCurrency }) {
 
     return {
       id: p.id,
+      deployment: p.deployment,
       protocol,
       protocolLogo,
       pool: pool.protocolTokenToCover,
@@ -254,6 +255,7 @@ export default function ActiveCoverages({ displayCurrency }) {
           premium={selectedCoverage.premium}
           capacity={selectedCoverage.capacity}
           policyId={selectedCoverage.id}
+          deployment={selectedCoverage.deployment}
         />
       )}
     </div>

--- a/frontend/app/components/MarketsTable.js
+++ b/frontend/app/components/MarketsTable.js
@@ -55,6 +55,7 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
     }
     entry.tvl += tvlNative
     entry.pools.push({
+      deployment: pool.deployment,
       token: pool.protocolTokenToCover,
       tokenName: getTokenName(pool.protocolTokenToCover),
       premium,
@@ -312,6 +313,7 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
           capacity={selectedPool.pool.capacity}
           poolId={selectedPool.market.id}
           yieldChoice={1}
+          deployment={selectedPool.pool.deployment}
         />
       )}
     </div>

--- a/frontend/app/config/deployments.js
+++ b/frontend/app/config/deployments.js
@@ -22,3 +22,7 @@ if (!deployments.length) {
 }
 
 export default deployments;
+
+export function getDeployment(name) {
+  return deployments.find((d) => d.name === name) || deployments[0];
+}

--- a/frontend/app/pool/[protocol]/[token]/page.js
+++ b/frontend/app/pool/[protocol]/[token]/page.js
@@ -474,8 +474,8 @@ export default function PoolDetailsPage() {
         <button className="flex-1 py-2.5 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-colors duration-150 ease-in-out text-sm sm:text-base flex items-center justify-center shadow-sm hover:shadow" onClick={()=>setPurchaseModalOpen(true)}>Purchase Coverage</button>
         <button className="flex-1 py-2.5 px-4 bg-green-600 hover:bg-green-700 text-white font-medium rounded-md transition-colors duration-150 ease-in-out text-sm sm:text-base flex items-center justify-center shadow-sm hover:shadow" onClick={()=>setProvideModalOpen(true)}>Provide Coverage</button>
       </div>
-      <CoverageModal isOpen={purchaseModalOpen} onClose={()=>setPurchaseModalOpen(false)} type="purchase" protocol={market.name} token={token} premium={processedPool?.premium} yield={processedPool?.underwriterYield}/>
-      <CoverageModal isOpen={provideModalOpen} onClose={()=>setProvideModalOpen(false)} type="provide" protocol={market.name} token={token} premium={processedPool?.premium} yield={processedPool?.underwriterYield}/>
+      <CoverageModal isOpen={purchaseModalOpen} onClose={()=>setPurchaseModalOpen(false)} type="purchase" protocol={market.name} token={token} premium={processedPool?.premium} yield={processedPool?.underwriterYield} deployment={pool?.deployment}/>
+      <CoverageModal isOpen={provideModalOpen} onClose={()=>setProvideModalOpen(false)} type="provide" protocol={market.name} token={token} premium={processedPool?.premium} yield={processedPool?.underwriterYield} deployment={pool?.deployment}/>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- allow UI components to select contracts from specific deployments
- fetch signer-connected contracts using deployment addresses
- plumb deployment information through coverage and allocation modals
- update markets and coverage tables to pass deployment identifiers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2dfb29a8832e8768525d2272f6dd