### PR TITLE
Fix catpool rewards API params handling

### DIFF
--- a/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
+++ b/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { catPool } from '../../../../../../lib/catPool';
 
-export async function GET(_req: Request, { params }: { params: { address: string; token: string } }) {
+export async function GET(_req: Request, { params }: { params: Promise<{ address: string; token: string }> }) {
+  const { address, token } = await params;
   try {
-    const amount = await catPool.calculateClaimableProtocolAssetRewards(params.address, params.token);
-    return NextResponse.json({ address: params.address, token: params.token, claimable: amount.toString() });
+    const amount = await catPool.calculateClaimableProtocolAssetRewards(address, token);
+    return NextResponse.json({ address, token, claimable: amount.toString() });
   } catch (err: any) {
     return NextResponse.json({ error: err.message }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- correctly await dynamic params in catpool rewards API route
- keep project coding style with semicolons

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: Cannot find module 'vitest/vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_684c2dc7b310832e82e2bfd486b82c82