### PR TITLE
Fix catpool rewards param handling

### DIFF
--- a/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
+++ b/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
@@ -1,17 +1,21 @@
-import { NextResponse } from 'next/server';
-import { provider } from '../../../../../../lib/provider';
-import CatPoolAbi from '../../../../../../abi/CatInsurancePool.json';
-import deployments from '../../../../../config/deployments';
-import { ethers } from 'ethers';
+import { NextResponse } from 'next/server'
+import { provider } from '../../../../../../lib/provider'
+import CatPoolAbi from '../../../../../../abi/CatInsurancePool.json'
+import deployments from '../../../../../config/deployments'
+import { ethers } from 'ethers'
 
-export async function GET(req: Request, { params }: { params: { address: string; token: string } }) {
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ address: string; token: string }> },
+) {
   try {
+    const { address, token } = await params
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
     const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
-    const amount = await cp.calculateClaimableProtocolAssetRewards(params.address, params.token);
-    return NextResponse.json({ address: params.address, token: params.token, claimable: amount.toString() });
+    const amount = await cp.calculateClaimableProtocolAssetRewards(address, token);
+    return NextResponse.json({ address, token, claimable: amount.toString() });
   } catch (err: any) {
     return NextResponse.json({ error: err.message }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- handle `params` as a promise in catpool rewards route

## Testing
- `npm test` *(fails: no test specified)*
- `cd frontend && npm test` *(fails: vitest missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c3488a1e4832ea205cdfe15cffcdd