### PR TITLE
Add deployment-aware provider helpers

### DIFF
--- a/frontend/app/api/adapters/route.ts
+++ b/frontend/app/api/adapters/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getCapitalPool } from '../../../lib/capitalPool';
-import { provider } from '../../../lib/provider';
+import { getProvider } from '../../../lib/provider';
 import { ethers } from 'ethers';
 import deployments from '../../config/deployments';
 
@@ -15,7 +15,8 @@ export async function GET(req: Request) {
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
 
-    const cp = getCapitalPool(dep.capitalPool);
+    const provider = getProvider(dep);
+    const cp = getCapitalPool(dep.capitalPool, provider);
 
     const adapters: { address: string; apr: string; asset: string }[] = [];
     for (let i = 0; i < 20; i++) {

--- a/frontend/app/api/catpool/apr/route.ts
+++ b/frontend/app/api/catpool/apr/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../lib/provider';
+import { getProvider } from '../../../../lib/provider';
 import { ethers } from 'ethers';
 import CatPoolAbi from '../../../../abi/CatInsurancePool.json';
 import deployments from '../../../config/deployments';
@@ -12,6 +12,7 @@ export async function GET(req: Request) {
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
 
+    const provider = getProvider(dep);
     const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
     const adapterAddr = await cp.adapter();
     let apr = '0';

--- a/frontend/app/api/catpool/liquidusdc/route.ts
+++ b/frontend/app/api/catpool/liquidusdc/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../lib/provider';
+import { getProvider } from '../../../../lib/provider';
 import CatPoolAbi from '../../../../abi/CatInsurancePool.json';
 import deployments from '../../../config/deployments';
 import { ethers } from 'ethers';
@@ -9,6 +9,7 @@ export async function GET(req: Request) {
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const provider = getProvider(dep);
     const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
     const amount = await cp.liquidUsdc();
     return NextResponse.json({ liquidUsdc: amount.toString() });

--- a/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
+++ b/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../../../lib/provider';
+import { getProvider } from '../../../../../../lib/provider';
 import CatPoolAbi from '../../../../../../abi/CatInsurancePool.json';
 import deployments from '../../../../../config/deployments';
 import { ethers } from 'ethers';
@@ -9,6 +9,7 @@ export async function GET(req: Request, { params }: { params: { address: string;
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const provider = getProvider(dep);
     const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
     const amount = await cp.calculateClaimableProtocolAssetRewards(params.address, params.token);
     return NextResponse.json({ address: params.address, token: params.token, claimable: amount.toString() });

--- a/frontend/app/api/catpool/user/[address]/route.ts
+++ b/frontend/app/api/catpool/user/[address]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../../lib/provider';
+import { getProvider } from '../../../../../lib/provider';
 import CatPoolAbi from '../../../../../abi/CatInsurancePool.json';
 import ERC20 from '../../../../../abi/ERC20.json';
 import { ethers } from 'ethers';
@@ -10,6 +10,7 @@ export async function GET(req: Request, { params }: { params: { address: string 
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const provider = getProvider(dep);
     const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
 
     const addr = params.address.toLowerCase();

--- a/frontend/app/api/policies/user/[address]/route.ts
+++ b/frontend/app/api/policies/user/[address]/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { policyNft } from '@/lib/policyNft'
 import { getRiskManager } from '@/lib/riskManager'
+import { getProvider } from '@/lib/provider'
 import deployments from '../../../../config/deployments'
 
 export async function GET(
@@ -23,7 +24,8 @@ export async function GET(
           const p = await policyNft.getPolicy(i)
           let deployment: string | null = null
           for (const dep of deployments) {
-            const rm = getRiskManager(dep.riskManager)
+            const provider = getProvider(dep)
+            const rm = getRiskManager(dep.riskManager, provider)
             try {
               await rm.getPoolInfo(p.poolId)
               deployment = dep.name

--- a/frontend/app/api/pools/[id]/route.ts
+++ b/frontend/app/api/pools/[id]/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 // import your provider and contract instances
 import { getRiskManager } from '../../../../lib/riskManager';
 import deployments from '../../../config/deployments';
+import { getProvider } from '../../../../lib/provider';
 
 export async function GET(
   _request: Request,
@@ -15,7 +16,8 @@ export async function GET(
   }
 
   for (const dep of deployments) {
-    const riskManager = getRiskManager(dep.riskManager);
+    const provider = getProvider(dep);
+    const riskManager = getRiskManager(dep.riskManager, provider);
     try {
       const poolInfo = await riskManager.getPoolInfo(idNum);
       return NextResponse.json({ id: idNum, deployment: dep.name, poolInfo });

--- a/frontend/app/api/pools/list/route.ts
+++ b/frontend/app/api/pools/list/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { getRiskManager } from '../../../../lib/riskManager';
 import { getPriceOracle } from '../../../../lib/priceOracle';
+import { getProvider } from '../../../../lib/provider';
 import deployments from '../../../config/deployments';
 import { ethers } from 'ethers';
 
@@ -103,8 +104,9 @@ function calcPremiumRateBps(pool: any): bigint {
 export async function GET() {
   const allPools: any[] = []
   for (const dep of deployments) {
-    const riskManager = getRiskManager(dep.riskManager)
-    const priceOracle = getPriceOracle(dep.priceOracle)
+    const provider = getProvider(dep)
+    const riskManager = getRiskManager(dep.riskManager, provider)
+    const priceOracle = getPriceOracle(dep.priceOracle, provider)
     try {
     /* 1️⃣ How many pools exist? */
     let count = 0n;

--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getRiskManager } from '../../../lib/riskManager'
 import { getCapitalPool } from '../../../lib/capitalPool'
+import { getProvider } from '../../../lib/provider'
 import deployments from '../../config/deployments'
 
 export async function GET(req: Request) {
@@ -8,8 +9,9 @@ export async function GET(req: Request) {
     const url = new URL(req.url)
     const depName = url.searchParams.get('deployment')
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
-    const rm = getRiskManager(dep.riskManager)
-    const cp = getCapitalPool(dep.capitalPool)
+    const provider = getProvider(dep)
+    const rm = getRiskManager(dep.riskManager, provider)
+    const cp = getCapitalPool(dep.capitalPool, provider)
 
     const [cooldown, claimFee, notice] = await Promise.all([
       (rm as any).COVER_COOLDOWN_PERIOD(),

--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { getCapitalPool } from '@/lib/capitalPool'
 import { getRiskManager } from '@/lib/riskManager'
+import { getProvider } from '@/lib/provider'
 import deployments from '../../../config/deployments'
 
 export async function GET(
@@ -15,8 +16,9 @@ export async function GET(
     const details: any[] = []
 
     for (const dep of deployments) {
-      const cp = getCapitalPool(dep.capitalPool)
-      const rm = getRiskManager(dep.riskManager)
+      const provider = getProvider(dep)
+      const cp = getCapitalPool(dep.capitalPool, provider)
+      const rm = getRiskManager(dep.riskManager, provider)
 
       try {
         const account = await cp.getUnderwriterAccount(addr)

--- a/frontend/lib/capitalPool.ts
+++ b/frontend/lib/capitalPool.ts
@@ -1,11 +1,14 @@
-import { ethers } from 'ethers';
-import CapitalPool from '../abi/CapitalPool.json';
-import { provider } from './provider';
+import { ethers } from 'ethers'
+import CapitalPool from '../abi/CapitalPool.json'
+import { getProvider, provider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_CAPITAL_POOL_ADDRESS as string;
 
-export function getCapitalPool(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, CapitalPool, provider);
+export function getCapitalPool(
+  address: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  return new ethers.Contract(address, CapitalPool, prov)
 }
 
 export const capitalPool = getCapitalPool();
@@ -28,27 +31,41 @@ export function getCapitalPoolWriter(address: string = DEFAULT_ADDRESS) {
 }
 
 // Helper to query the underlying ERC20 asset used by the capital pool
-export async function getUnderlyingAssetAddress(address: string = DEFAULT_ADDRESS) {
-  const cp = new ethers.Contract(address, ['function underlyingAsset() view returns (address)'], provider);
-  return await cp.underlyingAsset();
+export async function getUnderlyingAssetAddress(
+  address: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  const cp = new ethers.Contract(
+    address,
+    ['function underlyingAsset() view returns (address)'],
+    prov,
+  )
+  return await cp.underlyingAsset()
 }
 
-export async function getUnderlyingAssetDecimals(address: string = DEFAULT_ADDRESS) {
-  const assetAddr = await getUnderlyingAssetAddress(address);
+export async function getUnderlyingAssetDecimals(
+  address: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  const assetAddr = await getUnderlyingAssetAddress(address, prov)
   const token = new ethers.Contract(
     assetAddr,
     ['function decimals() view returns (uint8)'],
-    provider,
-  );
-  return await token.decimals();
+    prov,
+  )
+  return await token.decimals()
 }
 
-export async function getUnderlyingAssetBalance(address: string, poolAddr: string = DEFAULT_ADDRESS) {
-  const assetAddr = await getUnderlyingAssetAddress(poolAddr);
+export async function getUnderlyingAssetBalance(
+  address: string,
+  poolAddr: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  const assetAddr = await getUnderlyingAssetAddress(poolAddr, prov)
   const token = new ethers.Contract(
     assetAddr,
     ['function balanceOf(address) view returns (uint256)'],
-    provider,
-  );
-  return await token.balanceOf(address);
+    prov,
+  )
+  return await token.balanceOf(address)
 }

--- a/frontend/lib/catPool.ts
+++ b/frontend/lib/catPool.ts
@@ -1,32 +1,27 @@
-import { ethers } from 'ethers';
-import CatPool from '../abi/CatInsurancePool.json';
-// lib/provider.ts (or wherever you construct it)
+import { ethers } from 'ethers'
+import CatPool from '../abi/CatInsurancePool.json'
+import { getProvider, provider } from './provider'
 
+const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
+export function getCatPool(
+  address: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  return new ethers.Contract(address, CatPool, prov)
+}
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
+export const catPool = getCatPool()
 
-export const catPool = new ethers.Contract(
-  process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
-  CatPool,
-  provider
-);
-
-export function getCatPoolWriter() {
+export function getCatPoolWriter(prov = provider) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
-  const signer = new ethers.Wallet(pk, provider);
-  return new ethers.Contract(process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string, CatPool, signer);
+  const signer = new ethers.Wallet(pk, prov);
+  return new ethers.Contract(
+    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
+    CatPool,
+    signer,
+  );
 }
 
 export async function getCatPoolWithSigner() {
@@ -43,40 +38,40 @@ export async function getCatPoolWithSigner() {
   );
 }
 
-export async function getUsdcAddress() {
+export async function getUsdcAddress(prov = getProvider()) {
   const cp = new ethers.Contract(
     process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
     ['function usdc() view returns (address)'],
-    provider,
+    prov,
   );
   return await cp.usdc();
 }
 
-export async function getUsdcDecimals() {
-  const addr = await getUsdcAddress();
+export async function getUsdcDecimals(prov = getProvider()) {
+  const addr = await getUsdcAddress(prov);
   const token = new ethers.Contract(
     addr,
     ['function decimals() view returns (uint8)'],
-    provider,
+    prov,
   );
   return await token.decimals();
 }
 
-export async function getCatShareAddress() {
+export async function getCatShareAddress(prov = getProvider()) {
   const cp = new ethers.Contract(
     process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
     ['function catShareToken() view returns (address)'],
-    provider,
+    prov,
   );
   return await cp.catShareToken();
 }
 
-export async function getCatShareDecimals() {
-  const addr = await getCatShareAddress();
+export async function getCatShareDecimals(prov = getProvider()) {
+  const addr = await getCatShareAddress(prov);
   const token = new ethers.Contract(
     addr,
     ['function decimals() view returns (uint8)'],
-    provider,
+    prov,
   );
   return await token.decimals();
 }

--- a/frontend/lib/committee.ts
+++ b/frontend/lib/committee.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import Committee from '../abi/Committee.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const ADDRESS = process.env.NEXT_PUBLIC_COMMITTEE_ADDRESS as string
 
@@ -9,7 +9,11 @@ if (!ADDRESS) {
   throw new Error('NEXT_PUBLIC_COMMITTEE_ADDRESS not set')
 }
 
-export const committee = new ethers.Contract(ADDRESS, Committee, provider)
+export function getCommittee(prov = getProvider()) {
+  return new ethers.Contract(ADDRESS, Committee, prov)
+}
+
+export const committee = getCommittee()
 
 export async function getCommitteeWithSigner() {
   if (typeof window === 'undefined' || !window.ethereum)

--- a/frontend/lib/erc20.ts
+++ b/frontend/lib/erc20.ts
@@ -1,13 +1,13 @@
 import { ethers } from 'ethers'
 import ERC20 from '../abi/ERC20.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const rpc = process.env.NEXT_PUBLIC_RPC_URL;
 console.log('RPC URL:', rpc);
 
 
-export function getERC20(address: string) {
-  return new ethers.Contract(address, ERC20, provider)
+export function getERC20(address: string, prov = getProvider()) {
+  return new ethers.Contract(address, ERC20, prov)
 }
 
 export async function getERC20WithSigner(address: string) {
@@ -18,27 +18,27 @@ export async function getERC20WithSigner(address: string) {
   return new ethers.Contract(address, ERC20, signer)
 }
 
-export async function getTokenSymbol(address: string) {
+export async function getTokenSymbol(address: string, prov = getProvider()) {
   try {
-    const c = getERC20(address)
+    const c = getERC20(address, prov)
     return await c.symbol()
   } catch {
     return ''
   }
 }
 
-export async function getTokenName(address: string) {
+export async function getTokenName(address: string, prov = getProvider()) {
   try {
-    const c = getERC20(address)
+    const c = getERC20(address, prov)
     return await c.name()
   } catch {
     return ''
   }
 }
 
-export async function getTokenDecimals(address: string) {
+export async function getTokenDecimals(address: string, prov = getProvider()) {
   try {
-    const c = getERC20(address)
+    const c = getERC20(address, prov)
     return await c.decimals()
   } catch {
     return 18

--- a/frontend/lib/policyNft.ts
+++ b/frontend/lib/policyNft.ts
@@ -1,21 +1,9 @@
-import { ethers } from 'ethers';
-import PolicyNFT from '../abi/PolicyNFT.json';
+import { ethers } from 'ethers'
+import PolicyNFT from '../abi/PolicyNFT.json'
+import { getProvider, provider } from './provider'
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
-
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
-
-const rpc = process.env.NEXT_PUBLIC_RPC_URL;
-console.log('RPC URL:', rpc);
+const rpc = process.env.NEXT_PUBLIC_RPC_URL
+console.log('RPC URL:', rpc)
 
 
 const READ_ADDRESS =
@@ -27,15 +15,19 @@ if (!READ_ADDRESS) {
   throw new Error('POLICY_NFT_ADDRESS not set');
 }
 
-export const policyNft = new ethers.Contract(
-  READ_ADDRESS as string,
-  PolicyNFT,
-  provider,
-);
+export function getPolicyNft(prov = getProvider()) {
+  return new ethers.Contract(READ_ADDRESS as string, PolicyNFT, prov)
+}
 
-export function getPolicyNftWriter() {
+export const policyNft = getPolicyNft()
+
+export function getPolicyNftWriter(prov = provider) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
-  const signer = new ethers.Wallet(pk, provider);
-  return new ethers.Contract(process.env.POLICY_NFT_ADDRESS as string, PolicyNFT, signer);
+  const signer = new ethers.Wallet(pk, prov);
+  return new ethers.Contract(
+    process.env.POLICY_NFT_ADDRESS as string,
+    PolicyNFT,
+    signer,
+  );
 }

--- a/frontend/lib/priceOracle.ts
+++ b/frontend/lib/priceOracle.ts
@@ -1,11 +1,14 @@
 import { ethers } from 'ethers'
 import PriceOracle from '../abi/PriceOracle.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_PRICE_ORACLE_ADDRESS as string;
 
-export function getPriceOracle(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, PriceOracle, provider);
+export function getPriceOracle(
+  address: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  return new ethers.Contract(address, PriceOracle, prov)
 }
 
 export const priceOracle = getPriceOracle();

--- a/frontend/lib/provider.ts
+++ b/frontend/lib/provider.ts
@@ -1,14 +1,19 @@
-import { ethers } from 'ethers';
+import { ethers } from 'ethers'
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??     // dev in the browser
-  process.env.RPC_URL ??                 // server / CI
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';  // fallback
+const FALLBACK_RPC =
+  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe'
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
+export function getProvider(dep?: { rpcUrl?: string }) {
+  const url =
+    dep?.rpcUrl ??
+    process.env.NEXT_PUBLIC_RPC_URL ?? // dev in the browser
+    process.env.RPC_URL ?? // server / CI
+    FALLBACK_RPC
+
+  return new ethers.providers.StaticJsonRpcProvider(url, {
     name: 'base',
     chainId: 8453,
-  },
-);
+  })
+}
+
+export const provider = getProvider()

--- a/frontend/lib/riskManager.ts
+++ b/frontend/lib/riskManager.ts
@@ -1,7 +1,7 @@
 // lib/riskManager.ts
-import { ethers } from 'ethers';
-import RiskManager from '../abi/RiskManager.json';
-import { provider } from './provider';
+import { ethers } from 'ethers'
+import RiskManager from '../abi/RiskManager.json'
+import { getProvider, provider } from './provider'
 
 /* ───────────────────────────────
    Validate & create read-only contract
@@ -14,8 +14,11 @@ if (!DEFAULT_ADDRESS) {
   throw new Error('NEXT_PUBLIC_RISK_MANAGER_ADDRESS not set');
 }
 
-export function getRiskManager(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, RiskManager, provider);
+export function getRiskManager(
+  address: string = DEFAULT_ADDRESS,
+  prov = getProvider(),
+) {
+  return new ethers.Contract(address, RiskManager, prov)
 }
 
 export const riskManager = getRiskManager();

--- a/frontend/lib/staking.ts
+++ b/frontend/lib/staking.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import Staking from '../abi/Staking.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 // Validate presence of the staking contract address
 const ADDRESS = process.env.NEXT_PUBLIC_STAKING_ADDRESS as string
@@ -10,7 +10,11 @@ if (!ADDRESS) {
   throw new Error('NEXT_PUBLIC_STAKING_ADDRESS not set')
 }
 
-export const staking = new ethers.Contract(ADDRESS, Staking, provider)
+export function getStaking(prov = getProvider()) {
+  return new ethers.Contract(ADDRESS, Staking, prov)
+}
+
+export const staking = getStaking()
 
 export async function getStakingWithSigner() {
   if (typeof window === 'undefined' || !window.ethereum)


### PR DESCRIPTION
## Summary
- support dynamic provider configuration
- pass providers through contract helpers
- use correct provider in API routes

## Testing
- `npm test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_684c34a9e580832e922e4203624a19bb