### PR TITLE
Add per-deployment provider selection

### DIFF
--- a/frontend/app/api/adapters/route.ts
+++ b/frontend/app/api/adapters/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getCapitalPool } from '../../../lib/capitalPool';
-import { provider } from '../../../lib/provider';
+import { getProvider } from '../../../lib/provider';
 import { ethers } from 'ethers';
 import deployments from '../../config/deployments';
 
@@ -15,13 +15,13 @@ export async function GET(req: Request) {
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
 
-    const cp = getCapitalPool(dep.capitalPool);
+    const cp = getCapitalPool(dep.capitalPool, dep.name);
 
     const adapters: { address: string; apr: string; asset: string }[] = [];
     for (let i = 0; i < 20; i++) {
       try {
         const addr = await (cp as any).activeYieldAdapterAddresses(i);
-        const contract = new ethers.Contract(addr, ADAPTER_ABI, provider);
+        const contract = new ethers.Contract(addr, ADAPTER_ABI, getProvider(dep.name));
         let apr = '0';
         let asset = ethers.constants.AddressZero;
         try {

--- a/frontend/app/api/catpool/apr/route.ts
+++ b/frontend/app/api/catpool/apr/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../lib/provider';
+import { getProvider } from '../../../../lib/provider';
 import { ethers } from 'ethers';
 import CatPoolAbi from '../../../../abi/CatInsurancePool.json';
 import deployments from '../../../config/deployments';
@@ -12,11 +12,11 @@ export async function GET(req: Request) {
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
 
-    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, getProvider(dep.name));
     const adapterAddr = await cp.adapter();
     let apr = '0';
     if (adapterAddr !== ethers.constants.AddressZero) {
-      const contract = new ethers.Contract(adapterAddr, APR_ABI, provider);
+      const contract = new ethers.Contract(adapterAddr, APR_ABI, getProvider(dep.name));
       try {
         const res = await contract.currentApr();
         apr = res.toString();

--- a/frontend/app/api/catpool/claim/route.ts
+++ b/frontend/app/api/catpool/claim/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { tokens, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCatPoolWriter(dep.catPool);
+    const cp = getCatPoolWriter(dep.catPool, dep.name);
     const tx = await cp.claimProtocolAssetRewards(tokens);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/catpool/deposit/route.ts
+++ b/frontend/app/api/catpool/deposit/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { amount, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCatPoolWriter(dep.catPool);
+    const cp = getCatPoolWriter(dep.catPool, dep.name);
     const tx = await cp.depositLiquidity(amount);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/catpool/liquidusdc/route.ts
+++ b/frontend/app/api/catpool/liquidusdc/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../lib/provider';
+import { getProvider } from '../../../../lib/provider';
 import CatPoolAbi from '../../../../abi/CatInsurancePool.json';
 import deployments from '../../../config/deployments';
 import { ethers } from 'ethers';
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, getProvider(dep.name));
     const amount = await cp.liquidUsdc();
     return NextResponse.json({ liquidUsdc: amount.toString() });
   } catch (err: any) {

--- a/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
+++ b/frontend/app/api/catpool/rewards/[address]/[token]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { provider } from '../../../../../../lib/provider'
+import { getProvider } from '../../../../../../lib/provider'
 import CatPoolAbi from '../../../../../../abi/CatInsurancePool.json'
 import deployments from '../../../../../config/deployments'
 import { ethers } from 'ethers'
@@ -13,7 +13,7 @@ export async function GET(
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, getProvider(dep.name));
     const amount = await cp.calculateClaimableProtocolAssetRewards(address, token);
     return NextResponse.json({ address, token, claimable: amount.toString() });
   } catch (err: any) {

--- a/frontend/app/api/catpool/user/[address]/route.ts
+++ b/frontend/app/api/catpool/user/[address]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { provider } from '../../../../../lib/provider';
+import { getProvider } from '../../../../../lib/provider';
 import CatPoolAbi from '../../../../../abi/CatInsurancePool.json';
 import ERC20 from '../../../../../abi/ERC20.json';
 import { ethers } from 'ethers';
@@ -10,11 +10,11 @@ export async function GET(req: Request, { params }: { params: { address: string 
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, provider);
+    const cp = new ethers.Contract(dep.catPool, CatPoolAbi, getProvider(dep.name));
 
     const addr = params.address.toLowerCase();
     const catShareAddr = await cp.catShareToken();
-    const token = new ethers.Contract(catShareAddr, ERC20, provider);
+    const token = new ethers.Contract(catShareAddr, ERC20, getProvider(dep.name));
     const [balance, totalSupply, liquid] = await Promise.all([
       token.balanceOf(addr),
       token.totalSupply(),

--- a/frontend/app/api/catpool/withdraw/route.ts
+++ b/frontend/app/api/catpool/withdraw/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { shares, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCatPoolWriter(dep.catPool);
+    const cp = getCatPoolWriter(dep.catPool, dep.name);
     const tx = await cp.withdrawLiquidity(shares);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/claim/route.ts
+++ b/frontend/app/api/coverpool/claim/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { policyId, proof, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const rm = getRiskManagerWriter(dep.riskManager);
+    const rm = getRiskManagerWriter(dep.riskManager, dep.name);
     const tx = await rm.processClaim(policyId, proof);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/deposit/route.ts
+++ b/frontend/app/api/coverpool/deposit/route.ts
@@ -7,8 +7,8 @@ export async function POST(req: Request) {
   try {
     const { amount, yieldChoice, poolIds, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCapitalPoolWriter(dep.capitalPool);
-    const rm = getRiskManagerWriter(dep.riskManager);
+    const cp = getCapitalPoolWriter(dep.capitalPool, dep.name);
+    const rm = getRiskManagerWriter(dep.riskManager, dep.name);
     const tx = await cp.deposit(amount, yieldChoice);
     await tx.wait();
     if (poolIds && poolIds.length > 0) {

--- a/frontend/app/api/coverpool/execute-withdrawal/route.ts
+++ b/frontend/app/api/coverpool/execute-withdrawal/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: Request) {
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCapitalPoolWriter(dep.capitalPool);
+    const cp = getCapitalPoolWriter(dep.capitalPool, dep.name);
     const tx = await cp.executeWithdrawal();
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/purchase/route.ts
+++ b/frontend/app/api/coverpool/purchase/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { poolId, coverageAmount, initialPremiumDeposit, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const rm = getRiskManagerWriter(dep.riskManager);
+    const rm = getRiskManagerWriter(dep.riskManager, dep.name);
     const tx = await rm.purchaseCover(poolId, coverageAmount, initialPremiumDeposit);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/request-withdrawal/route.ts
+++ b/frontend/app/api/coverpool/request-withdrawal/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { shares, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCapitalPoolWriter(dep.capitalPool);
+    const cp = getCapitalPoolWriter(dep.capitalPool, dep.name);
     const tx = await cp.requestWithdrawal(shares);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/coverpool/settle/route.ts
+++ b/frontend/app/api/coverpool/settle/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { policyId, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const rm = getRiskManagerWriter(dep.riskManager);
+    const rm = getRiskManagerWriter(dep.riskManager, dep.name);
     const tx = await rm.settlePremium(policyId);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });

--- a/frontend/app/api/pools/[id]/route.ts
+++ b/frontend/app/api/pools/[id]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
   }
 
   for (const dep of deployments) {
-    const riskManager = getRiskManager(dep.riskManager);
+    const riskManager = getRiskManager(dep.riskManager, dep.name);
     try {
       const poolInfo = await riskManager.getPoolInfo(idNum);
       return NextResponse.json({ id: idNum, deployment: dep.name, poolInfo });

--- a/frontend/app/api/pools/list/route.ts
+++ b/frontend/app/api/pools/list/route.ts
@@ -104,8 +104,8 @@ function calcPremiumRateBps(pool: any): bigint {
 export async function GET() {
   const allPools: any[] = []
   for (const dep of deployments) {
-    const riskManager = getRiskManager(dep.riskManager)
-    const priceOracle = getPriceOracle(dep.priceOracle)
+    const riskManager = getRiskManager(dep.riskManager, dep.name)
+    const priceOracle = getPriceOracle(dep.priceOracle, dep.name)
     try {
     /* 1️⃣ How many pools exist? */
     let count = 0n;
@@ -135,7 +135,7 @@ export async function GET() {
     }
 
     /* 3️⃣ Pull each pool and compute derivatives via multicall */
-    const multicall = getMulticallReader(dep.multicallReader);
+    const multicall = getMulticallReader(dep.multicallReader, dep.name);
     const pools: any[] = [];
 
     const poolCalls = [] as { target: string; callData: string }[];

--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -8,8 +8,8 @@ export async function GET(req: Request) {
     const url = new URL(req.url)
     const depName = url.searchParams.get('deployment')
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
-    const rm = getRiskManager(dep.riskManager)
-    const cp = getCapitalPool(dep.capitalPool)
+    const rm = getRiskManager(dep.riskManager, dep.name)
+    const cp = getCapitalPool(dep.capitalPool, dep.name)
 
     const [cooldown, claimFee, notice] = await Promise.all([
       (rm as any).COVER_COOLDOWN_PERIOD(),

--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -15,8 +15,8 @@ export async function GET(
     const details: any[] = []
 
     for (const dep of deployments) {
-      const cp = getCapitalPool(dep.capitalPool)
-      const rm = getRiskManager(dep.riskManager)
+      const cp = getCapitalPool(dep.capitalPool, dep.name)
+      const rm = getRiskManager(dep.riskManager, dep.name)
 
       try {
         const account = await cp.getUnderwriterAccount(addr)

--- a/frontend/lib/capitalPool.ts
+++ b/frontend/lib/capitalPool.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers';
 import CapitalPool from '../abi/CapitalPool.json';
-import { provider } from './provider';
+import { getProvider, provider } from './provider';
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_CAPITAL_POOL_ADDRESS as string;
 
-export function getCapitalPool(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, CapitalPool, provider);
+export function getCapitalPool(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, CapitalPool, getProvider(deployment));
 }
 
 export const capitalPool = getCapitalPool();
@@ -20,35 +20,35 @@ export async function getCapitalPoolWithSigner(address: string = DEFAULT_ADDRESS
   return new ethers.Contract(address, CapitalPool, signer);
 }
 
-export function getCapitalPoolWriter(address: string = DEFAULT_ADDRESS) {
+export function getCapitalPoolWriter(address: string = DEFAULT_ADDRESS, deployment?: string) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
-  const signer = new ethers.Wallet(pk, provider);
+  const signer = new ethers.Wallet(pk, getProvider(deployment));
   return new ethers.Contract(address, CapitalPool, signer);
 }
 
 // Helper to query the underlying ERC20 asset used by the capital pool
-export async function getUnderlyingAssetAddress(address: string = DEFAULT_ADDRESS) {
-  const cp = new ethers.Contract(address, ['function underlyingAsset() view returns (address)'], provider);
+export async function getUnderlyingAssetAddress(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  const cp = new ethers.Contract(address, ['function underlyingAsset() view returns (address)'], getProvider(deployment));
   return await cp.underlyingAsset();
 }
 
-export async function getUnderlyingAssetDecimals(address: string = DEFAULT_ADDRESS) {
-  const assetAddr = await getUnderlyingAssetAddress(address);
+export async function getUnderlyingAssetDecimals(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  const assetAddr = await getUnderlyingAssetAddress(address, deployment);
   const token = new ethers.Contract(
     assetAddr,
     ['function decimals() view returns (uint8)'],
-    provider,
+    getProvider(deployment),
   );
   return await token.decimals();
 }
 
-export async function getUnderlyingAssetBalance(address: string, poolAddr: string = DEFAULT_ADDRESS) {
-  const assetAddr = await getUnderlyingAssetAddress(poolAddr);
+export async function getUnderlyingAssetBalance(address: string, poolAddr: string = DEFAULT_ADDRESS, deployment?: string) {
+  const assetAddr = await getUnderlyingAssetAddress(poolAddr, deployment);
   const token = new ethers.Contract(
     assetAddr,
     ['function balanceOf(address) view returns (uint256)'],
-    provider,
+    getProvider(deployment),
   );
   return await token.balanceOf(address);
 }

--- a/frontend/lib/catPool.ts
+++ b/frontend/lib/catPool.ts
@@ -1,32 +1,19 @@
 import { ethers } from 'ethers';
 import CatPool from '../abi/CatInsurancePool.json';
-// lib/provider.ts (or wherever you construct it)
+import { getProvider, provider } from './provider';
 
+const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string;
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
+export function getCatPool(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, CatPool, getProvider(deployment));
+}
+export const catPool = getCatPool();
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
-
-export const catPool = new ethers.Contract(
-  process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
-  CatPool,
-  provider
-);
-
-export function getCatPoolWriter() {
+export function getCatPoolWriter(address: string = DEFAULT_ADDRESS, deployment?: string) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
-  const signer = new ethers.Wallet(pk, provider);
-  return new ethers.Contract(process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string, CatPool, signer);
+  const signer = new ethers.Wallet(pk, getProvider(deployment));
+  return new ethers.Contract(address, CatPool, signer);
 }
 
 export async function getCatPoolWithSigner() {
@@ -37,46 +24,46 @@ export async function getCatPoolWithSigner() {
   const signer = await browserProvider.getSigner();
 
   return new ethers.Contract(
-    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
+    DEFAULT_ADDRESS,
     CatPool,
-    signer
+    signer,
   );
 }
 
-export async function getUsdcAddress() {
+export async function getUsdcAddress(address: string = DEFAULT_ADDRESS, deployment?: string) {
   const cp = new ethers.Contract(
-    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
+    address,
     ['function usdc() view returns (address)'],
-    provider,
+    getProvider(deployment),
   );
   return await cp.usdc();
 }
 
-export async function getUsdcDecimals() {
-  const addr = await getUsdcAddress();
+export async function getUsdcDecimals(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  const addr = await getUsdcAddress(address, deployment);
   const token = new ethers.Contract(
     addr,
     ['function decimals() view returns (uint8)'],
-    provider,
+    getProvider(deployment),
   );
   return await token.decimals();
 }
 
-export async function getCatShareAddress() {
+export async function getCatShareAddress(address: string = DEFAULT_ADDRESS, deployment?: string) {
   const cp = new ethers.Contract(
-    process.env.NEXT_PUBLIC_CAT_POOL_ADDRESS as string,
+    address,
     ['function catShareToken() view returns (address)'],
-    provider,
+    getProvider(deployment),
   );
   return await cp.catShareToken();
 }
 
-export async function getCatShareDecimals() {
-  const addr = await getCatShareAddress();
+export async function getCatShareDecimals(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  const addr = await getCatShareAddress(address, deployment);
   const token = new ethers.Contract(
     addr,
     ['function decimals() view returns (uint8)'],
-    provider,
+    getProvider(deployment),
   );
   return await token.decimals();
 }

--- a/frontend/lib/committee.ts
+++ b/frontend/lib/committee.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import Committee from '../abi/Committee.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const ADDRESS = process.env.NEXT_PUBLIC_COMMITTEE_ADDRESS as string
 
@@ -9,7 +9,11 @@ if (!ADDRESS) {
   throw new Error('NEXT_PUBLIC_COMMITTEE_ADDRESS not set')
 }
 
-export const committee = new ethers.Contract(ADDRESS, Committee, provider)
+export function getCommittee(address: string = ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, Committee, getProvider(deployment))
+}
+
+export const committee = getCommittee()
 
 export async function getCommitteeWithSigner() {
   if (typeof window === 'undefined' || !window.ethereum)

--- a/frontend/lib/erc20.ts
+++ b/frontend/lib/erc20.ts
@@ -1,13 +1,13 @@
 import { ethers } from 'ethers'
 import ERC20 from '../abi/ERC20.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const rpc = process.env.NEXT_PUBLIC_RPC_URL;
 console.log('RPC URL:', rpc);
 
 
-export function getERC20(address: string) {
-  return new ethers.Contract(address, ERC20, provider)
+export function getERC20(address: string, deployment?: string) {
+  return new ethers.Contract(address, ERC20, getProvider(deployment))
 }
 
 export async function getERC20WithSigner(address: string) {

--- a/frontend/lib/multicallReader.ts
+++ b/frontend/lib/multicallReader.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers'
 import MulticallReader from '../abi/MulticallReader.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_MULTICALL_READER_ADDRESS as string
 
-export function getMulticallReader(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, MulticallReader, provider)
+export function getMulticallReader(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, MulticallReader, getProvider(deployment))
 }
 
 export const multicallReader = getMulticallReader()

--- a/frontend/lib/policyNft.ts
+++ b/frontend/lib/policyNft.ts
@@ -1,18 +1,6 @@
 import { ethers } from 'ethers';
 import PolicyNFT from '../abi/PolicyNFT.json';
-
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
-
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
+import { getProvider, provider } from './provider';
 
 const rpc = process.env.NEXT_PUBLIC_RPC_URL;
 console.log('RPC URL:', rpc);
@@ -27,15 +15,15 @@ if (!READ_ADDRESS) {
   throw new Error('POLICY_NFT_ADDRESS not set');
 }
 
-export const policyNft = new ethers.Contract(
-  READ_ADDRESS as string,
-  PolicyNFT,
-  provider,
-);
+export function getPolicyNft(address: string = READ_ADDRESS as string, deployment?: string) {
+  return new ethers.Contract(address, PolicyNFT, getProvider(deployment));
+}
 
-export function getPolicyNftWriter() {
+export const policyNft = getPolicyNft();
+
+export function getPolicyNftWriter(address: string = process.env.POLICY_NFT_ADDRESS as string, deployment?: string) {
   const pk = process.env.PRIVATE_KEY;
   if (!pk) throw new Error('PRIVATE_KEY not set');
-  const signer = new ethers.Wallet(pk, provider);
-  return new ethers.Contract(process.env.POLICY_NFT_ADDRESS as string, PolicyNFT, signer);
+  const signer = new ethers.Wallet(pk, getProvider(deployment));
+  return new ethers.Contract(address, PolicyNFT, signer);
 }

--- a/frontend/lib/priceOracle.ts
+++ b/frontend/lib/priceOracle.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers'
 import PriceOracle from '../abi/PriceOracle.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_PRICE_ORACLE_ADDRESS as string;
 
-export function getPriceOracle(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, PriceOracle, provider);
+export function getPriceOracle(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, PriceOracle, getProvider(deployment));
 }
 
 export const priceOracle = getPriceOracle();

--- a/frontend/lib/provider.ts
+++ b/frontend/lib/provider.ts
@@ -1,14 +1,34 @@
 import { ethers } from 'ethers';
+import deployments from '../app/config/deployments';
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??     // dev in the browser
-  process.env.RPC_URL ??                 // server / CI
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';  // fallback
+const DEFAULT_RPC_URL =
+  process.env.NEXT_PUBLIC_RPC_URL ??
+  process.env.RPC_URL ??
+  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
 
-export const provider = new ethers.providers.StaticJsonRpcProvider(
-  RPC_URL,
-  {
-    name: 'base',
-    chainId: 8453,
-  },
-);
+const DEFAULT_CHAIN_ID = 8453;
+
+/**
+ * Return a StaticJsonRpcProvider for the given deployment name. If the
+ * deployment is not found, fall back to the default RPC URL and chain ID.
+ */
+export function getProvider(deploymentName?: string) {
+  let rpcUrl = DEFAULT_RPC_URL;
+  let chainId = DEFAULT_CHAIN_ID;
+
+  if (deploymentName) {
+    const dep = deployments.find((d) => d.name === deploymentName);
+    if (dep) {
+      if (dep.rpcUrl) rpcUrl = dep.rpcUrl;
+      if ((dep as any).chainId) chainId = (dep as any).chainId;
+    }
+  }
+
+  return new ethers.providers.StaticJsonRpcProvider(rpcUrl, {
+    name: deploymentName || 'default',
+    chainId,
+  });
+}
+
+/** Default provider using the first configured deployment or env vars. */
+export const provider = getProvider(deployments[0]?.name);

--- a/frontend/lib/riskManager.ts
+++ b/frontend/lib/riskManager.ts
@@ -1,7 +1,7 @@
 // lib/riskManager.ts
 import { ethers } from 'ethers';
 import RiskManager from '../abi/RiskManager.json';
-import { provider } from './provider';
+import { getProvider, provider } from './provider';
 
 /* ───────────────────────────────
    Validate & create read-only contract
@@ -14,8 +14,8 @@ if (!DEFAULT_ADDRESS) {
   throw new Error('NEXT_PUBLIC_RISK_MANAGER_ADDRESS not set');
 }
 
-export function getRiskManager(address: string = DEFAULT_ADDRESS) {
-  return new ethers.Contract(address, RiskManager, provider);
+export function getRiskManager(address: string = DEFAULT_ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, RiskManager, getProvider(deployment));
 }
 
 export const riskManager = getRiskManager();
@@ -51,14 +51,14 @@ export async function getRiskManagerWithSigner(address: string = DEFAULT_ADDRESS
    Server/CI writer (private-key signer)
 ────────────────────────────────── */
 
-export function getRiskManagerWriter(address: string = DEFAULT_ADDRESS) {
+export function getRiskManagerWriter(address: string = DEFAULT_ADDRESS, deployment?: string) {
   try {
     const pk = process.env.PRIVATE_KEY;
     if (!pk) {
       throw new Error('PRIVATE_KEY env var not set');
     }
 
-    const signer = new ethers.Wallet(pk, provider);
+    const signer = new ethers.Wallet(pk, getProvider(deployment));
     console.log('✅  Writer signer loaded – address:', signer.address);
 
     return new ethers.Contract(address, RiskManager, signer);

--- a/frontend/lib/staking.ts
+++ b/frontend/lib/staking.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import Staking from '../abi/Staking.json'
-import { provider } from './provider'
+import { getProvider, provider } from './provider'
 
 // Validate presence of the staking contract address
 const ADDRESS = process.env.NEXT_PUBLIC_STAKING_ADDRESS as string
@@ -10,7 +10,11 @@ if (!ADDRESS) {
   throw new Error('NEXT_PUBLIC_STAKING_ADDRESS not set')
 }
 
-export const staking = new ethers.Contract(ADDRESS, Staking, provider)
+export function getStaking(address: string = ADDRESS, deployment?: string) {
+  return new ethers.Contract(address, Staking, getProvider(deployment))
+}
+
+export const staking = getStaking()
 
 export async function getStakingWithSigner() {
   if (typeof window === 'undefined' || !window.ethereum)


### PR DESCRIPTION
## Summary
- expose `getProvider(deploymentName)` to return RPC providers by deployment
- allow contract wrappers to take a deployment name
- use `getProvider` in API routes so each request targets the right chain

## Testing
- `npm run test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_684c43eb2d48832ea59a445ce09f05b3