### PR TITLE
Update tests for new architecture

### DIFF
--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -6,8 +6,8 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "./CatShare.sol";
-import "./interfaces/IYieldAdapter.sol";
+import "../tokens/CatShare.sol";
+import "../interfaces/IYieldAdapter.sol";
 
 // Interface for the central Reward Distributor
 interface IRewardDistributor {

--- a/contracts/test/MockPolicyNFT.sol
+++ b/contracts/test/MockPolicyNFT.sol
@@ -74,6 +74,12 @@ contract MockPolicyNFT is Ownable, IPolicyNFT {
         _;
     }
 
+    // New helper mirroring the production contract's API
+    function setRiskManagerAddress(address _riskManager) external onlyOwner {
+        require(_riskManager != address(0), "MockPolicyNFT: RM address cannot be zero");
+        coverPoolAddress = _riskManager;
+    }
+
     function setCoverPoolAddress(address _coverPool) external onlyOwner {
         require(_coverPool != address(0), "MockPolicyNFT: CoverPool address cannot be zero");
         coverPoolAddress = _coverPool;

--- a/test/CatInsurancePool.test.js
+++ b/test/CatInsurancePool.test.js
@@ -18,7 +18,7 @@ async function deployFixture() {
   const catPool = await CatInsurancePool.deploy(usdc.target, adapter.target, owner.address);
 
   await adapter.connect(owner).setDepositor(catPool.target);
-  await catPool.connect(owner).setCoverPoolAddress(coverPoolAcc.address);
+  await catPool.connect(owner).setPolicyManagerAddress(coverPoolAcc.address);
 
   const catShare = await hardhatEthers.getContractAt("CatShare", await catPool.catShareToken());
 

--- a/test/risk-manager.test.js
+++ b/test/risk-manager.test.js
@@ -203,7 +203,7 @@ describe("RiskManager - purchaseCover", function () {
             await mockCatPool.getAddress()
         );
 
-        await mockPolicyNFT.setCoverPoolAddress(riskManager.target);
+        await mockPolicyNFT.setRiskManagerAddress(riskManager.target);
 
         const capitalAmount = ethers.parseUnits("100000", 6);
         const cpAddress = await mockCapitalPool.getAddress();
@@ -816,7 +816,7 @@ describe("RiskManager - claimPremiumRewards", function () {
             await mockCatPool.getAddress()
         );
 
-        await mockPolicyNFT.setCoverPoolAddress(riskManager.target);
+        await mockPolicyNFT.setRiskManagerAddress(riskManager.target);
 
         // Setup Pool and Underwriter
         const capitalAmount = ethers.parseUnits("100000", 6);
@@ -976,7 +976,7 @@ describe("RiskManager - claimDistressedAssets", function () {
         // apply losses. Without this setup, any claim processing in the fixture
         // would revert when `applyLosses` is called.
         await mockCapitalPool.connect(owner).setRiskManager(riskManager.target);
-        await mockPolicyNFT.setCoverPoolAddress(riskManager.target);
+        await mockPolicyNFT.setRiskManagerAddress(riskManager.target);
 
         // --- Setup Pool, Underwriter, and Policy ---
         await riskManager.addProtocolRiskPool(distressedToken.target, { base:0, slope1:0, slope2:0, kink:0 }, 1); // Pool 0


### PR DESCRIPTION
## Summary
- fix CatShare import path in `CatInsurancePool`
- add `setRiskManagerAddress` helper in `MockPolicyNFT`
- update CatInsurancePool and RiskManager tests to use new method names

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684ec6ff9b94832ea41fc1d337c047be