### PR TITLE
Add PoolManager to subgraph

### DIFF
--- a/subgraphs/insurance/abis/PoolManager.json
+++ b/subgraphs/insurance/abis/PoolManager.json
@@ -1,0 +1,29 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "registry", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "capital", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "rewards", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "rm", "type": "address" }
+    ],
+    "name": "AddressesSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "newBps", "type": "uint256" }
+    ],
+    "name": "CatPremiumShareSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "newCatPool", "type": "address" }
+    ],
+    "name": "CatPoolSet",
+    "type": "event"
+  }
+]

--- a/subgraphs/insurance/src/mapping.ts
+++ b/subgraphs/insurance/src/mapping.ts
@@ -43,6 +43,11 @@ import {
   RewardDistributorSet
 } from "../generated/CatInsurancePool/CatInsurancePool";
 import {
+  AddressesSet as PMAddressesSet,
+  CatPremiumShareSet,
+  CatPoolSet
+} from "../generated/PoolManager/PoolManager";
+import {
   PolicyPremiumAccountUpdated,
   Transfer,
   RiskManagerAddressSet,
@@ -459,4 +464,16 @@ export function handlePolicyManagerAddressSet(event: PolicyManagerAddressSet): v
 
 export function handleRewardDistributorSet(event: RewardDistributorSet): void {
   saveGeneric(event, "RewardDistributorSet");
+}
+
+export function handlePMAddressesSet(event: PMAddressesSet): void {
+  saveGeneric(event, "AddressesSet");
+}
+
+export function handleCatPremiumShareSet(event: CatPremiumShareSet): void {
+  saveGeneric(event, "CatPremiumShareSet");
+}
+
+export function handleCatPoolSet(event: CatPoolSet): void {
+  saveGeneric(event, "CatPoolSet");
 }

--- a/subgraphs/insurance/subgraph.yaml
+++ b/subgraphs/insurance/subgraph.yaml
@@ -154,6 +154,40 @@ dataSources:
       file: ./src/mapping.ts
 
   - kind: ethereum/contract
+    name: PoolManager
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000" # replace with deployed address
+      abi: PoolManager
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+        - Pool
+        - Underwriter
+        - Policy
+        - ContractOwner
+        - PoolUtilizationSnapshot
+        - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
+      abis:
+        - name: PoolManager
+          file: ./abis/PoolManager.json
+      eventHandlers:
+        - event: AddressesSet(indexed address,indexed address,indexed address,address)
+          handler: handlePMAddressesSet
+        - event: CatPremiumShareSet(uint256)
+          handler: handleCatPremiumShareSet
+        - event: CatPoolSet(indexed address)
+          handler: handleCatPoolSet
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
     name: PolicyNFT
     network: mainnet
     source:


### PR DESCRIPTION
## Summary
- support PoolManager contract events in the subgraph
- generate ABI for PoolManager and include in manifest
- handle new events in mapping

## Testing
- `npm run codegen` *(in `subgraphs/insurance`)*
- `npm test` *(fails: matchstick not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecda607ac832ebf1a459da8e2f49c