### PR TITLE
Add PoolRegistry datasource

### DIFF
--- a/subgraphs/insurance/abis/PoolRegistry.json
+++ b/subgraphs/insurance/abis/PoolRegistry.json
@@ -1,0 +1,21 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  }
+]

--- a/subgraphs/insurance/src/mapping.ts
+++ b/subgraphs/insurance/src/mapping.ts
@@ -59,6 +59,7 @@ import {
   CapitalPoolAddressSet
 } from "../generated/AaveV3Adapter/YieldAdapter";
 import { ProposalCreated, Voted, ProposalExecuted, BondResolved, RewardClaimed } from "../generated/Committee/Committee";
+import { OwnershipTransferred as PoolRegistryOwnershipTransferred } from "../generated/PoolRegistry/PoolRegistry";
 
 function saveGeneric(event: ethereum.Event, name: string): void {
   let id = event.transaction.hash.toHex() + "-" + event.logIndex.toString();
@@ -363,6 +364,13 @@ export function handleCapitalPoolOwnershipTransferred(
 
 export function handlePolicyNFTOwnershipTransferred(
   event: PolicyNFTOwnershipTransferred
+): void {
+  saveGeneric(event, "OwnershipTransferred");
+  saveOwner(event, event.params.newOwner);
+}
+
+export function handlePoolRegistryOwnershipTransferred(
+  event: PoolRegistryOwnershipTransferred
 ): void {
   saveGeneric(event, "OwnershipTransferred");
   saveOwner(event, event.params.newOwner);

--- a/subgraphs/insurance/subgraph.yaml
+++ b/subgraphs/insurance/subgraph.yaml
@@ -102,6 +102,35 @@ dataSources:
       file: ./src/mapping.ts
 
   - kind: ethereum/contract
+    name: PoolRegistry
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000" # replace with deployed address
+      abi: PoolRegistry
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+        - Pool
+        - Underwriter
+        - Policy
+        - ContractOwner
+        - PoolUtilizationSnapshot
+        - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
+      abis:
+        - name: PoolRegistry
+          file: ./abis/PoolRegistry.json
+      eventHandlers:
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handlePoolRegistryOwnershipTransferred
+      file: ./src/mapping.ts
+  - kind: ethereum/contract
     name: CatInsurancePool
     network: mainnet
     source:


### PR DESCRIPTION
## Summary
- add PoolRegistry ABI
- handle PoolRegistry ownership transfers
- include PoolRegistry contract in subgraph

## Testing
- `npm run test` *(fails: matchstick not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed97ef870832e96c198204c819c7f