### PR TITLE
Add new RiskManagerV2 subgraph source

### DIFF
--- a/subgraphs/README.md
+++ b/subgraphs/README.md
@@ -7,7 +7,9 @@ The `insurance` subgraph indexes events emitted by `RiskManager`,
 `CapitalPool`, `CatInsurancePool` and `PolicyNFT`.  Each data source now has a
 `deployment` context so multiple deployments can be indexed by duplicating the
 entries in `subgraph.yaml` with different addresses and `deployment` names.
-Update the placeholder contract addresses before deployment.
+Update the placeholder contract addresses before deployment. The manifest now
+includes a second `RiskManagerV2` data source that can be pointed at the new
+RiskManager contract.
 
 Entities include a `deployment` field allowing queries to filter by the
 originating deployment.

--- a/subgraphs/insurance/subgraph.yaml
+++ b/subgraphs/insurance/subgraph.yaml
@@ -56,6 +56,57 @@ dataSources:
       file: ./src/mapping.ts
 
   - kind: ethereum/contract
+    name: RiskManagerV2
+    network: mainnet
+    source:
+      address: "0x0000000000000000000000000000000000000000" # replace with new deployed address
+      abi: RiskManager
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - GenericEvent
+        - Pool
+        - Underwriter
+        - Policy
+        - ContractOwner
+        - PoolUtilizationSnapshot
+        - PoolUtilizationSnapshot
+        - Claim
+        - PolicyCreatedEvent
+        - PolicyLapsedEvent
+        - PremiumPaidEvent
+      abis:
+        - name: RiskManager
+          file: ./abis/RiskManager.json
+      eventHandlers:
+        - event: PoolAdded(indexed uint256,indexed address,uint8)
+          handler: handlePoolAdded
+        - event: CapitalAllocated(indexed address,indexed uint256,uint256)
+          handler: handleCapitalAllocated
+        - event: CapitalDeallocated(indexed address,indexed uint256,uint256)
+          handler: handleCapitalDeallocated
+        - event: PremiumPaid(indexed uint256,uint256,uint256,uint256,uint256)
+          handler: handlePremiumPaid
+        - event: ClaimProcessed(indexed uint256,indexed uint256,indexed address,uint256)
+          handler: handleClaimProcessed
+        - event: PolicyCreated(indexed address,indexed uint256,indexed uint256,uint256,uint256)
+          handler: handlePolicyCreated
+        - event: IncidentReported(indexed uint256,bool)
+          handler: handleIncidentReported
+        - event: PolicyLapsed(indexed uint256)
+          handler: handlePolicyLapsed
+        - event: PremiumRewardsClaimed(indexed address,indexed uint256,uint256)
+          handler: handlePremiumRewardsClaimed
+        - event: DistressedAssetRewardsClaimed(indexed address,indexed uint256,indexed address,uint256)
+          handler: handleDistressedAssetRewardsClaimed
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleRiskManagerOwnershipTransferred
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
     name: CapitalPool
     network: mainnet
     source:


### PR DESCRIPTION
## Summary
- add a new `RiskManagerV2` data source to the insurance subgraph
- document new data source in the subgraph README

## Testing
- `npm run build` *(fails: Failed to compile data source mapping)*

------
https://chatgpt.com/codex/tasks/task_e_684edf07cdf0832ea1c406520721bd05