### PR TITLE
Integrate PolicyManager contract

### DIFF
--- a/frontend/abi/PoolManager.json
+++ b/frontend/abi/PoolManager.json
@@ -2,10 +2,43 @@
   {
     "inputs": [],
     "name": "catPremiumBps",
-    "outputs": [
-      {"internalType": "uint256", "name": "", "type": "uint256"}
-    ],
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "_poolId", "type": "uint256"},
+      {"internalType": "uint256", "name": "_coverageAmount", "type": "uint256"},
+      {"internalType": "uint256", "name": "_initialPremiumDeposit", "type": "uint256"}
+    ],
+    "name": "purchaseCover",
+    "outputs": [{"internalType": "uint256", "name": "policyId", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "_policyId", "type": "uint256"}],
+    "name": "cancelCover",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "_policyId", "type": "uint256"},
+      {"internalType": "uint256", "name": "_premiumAmount", "type": "uint256"}
+    ],
+    "name": "addPremium",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "_policyId", "type": "uint256"}],
+    "name": "lapsePolicy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/frontend/app/api/coverpool/purchase/route.ts
+++ b/frontend/app/api/coverpool/purchase/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
-import { getRiskManagerWriter } from '../../../../lib/riskManager';
+import { getPoolManagerWriter } from '../../../../lib/poolManager';
 import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
   try {
     const { poolId, coverageAmount, initialPremiumDeposit, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const rm = getRiskManagerWriter(dep.riskManager, dep.name);
-    const tx = await rm.purchaseCover(poolId, coverageAmount, initialPremiumDeposit);
+    const pm = getPoolManagerWriter(dep.poolManager, dep.name);
+    const tx = await pm.purchaseCover(poolId, coverageAmount, initialPremiumDeposit);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });
   } catch (err: any) {

--- a/frontend/app/components/CoverageModal.js
+++ b/frontend/app/components/CoverageModal.js
@@ -6,6 +6,7 @@ import { Info } from "lucide-react"
 import { ethers } from "ethers" // v5 namespace import
 import { useAccount } from "wagmi"
 import { getRiskManagerWithSigner } from "../../lib/riskManager"
+import { getPoolManagerWithSigner } from "../../lib/poolManager"
 import {
   getCapitalPoolWithSigner,
   getUnderlyingAssetBalance,
@@ -135,8 +136,8 @@ export default function CoverageModal({
       const signerAddress = await tokenContract.signer.getAddress()
 
       if (type === "purchase") {
-        const rm = await getRiskManagerWithSigner(dep.riskManager)
-        const rmAddress = dep.riskManager
+        const pm = await getPoolManagerWithSigner(dep.poolManager)
+        const pmAddress = dep.poolManager
 
         const amountBn = ethers.utils.parseUnits(amount, dec) // coverage amount
 
@@ -146,14 +147,14 @@ export default function CoverageModal({
         const depositBn = ethers.utils.parseUnits(depositTotal.toFixed(dec), dec)
 
         // Ensure sufficient allowance for the premium deposit
-        const allowance = await tokenContract.allowance(signerAddress, rmAddress)
+        const allowance = await tokenContract.allowance(signerAddress, pmAddress)
 
         if (allowance.lt(depositBn)) {
-          const approveTx = await tokenContract.approve(rmAddress, depositBn)
+          const approveTx = await tokenContract.approve(pmAddress, depositBn)
           await approveTx.wait()
         }
 
-        const tx = await rm.purchaseCover(poolId, amountBn, depositBn)
+        const tx = await pm.purchaseCover(poolId, amountBn, depositBn)
         await tx.wait()
       } else {
         // "provide" flow

--- a/frontend/app/components/ManageCoverageModal.js
+++ b/frontend/app/components/ManageCoverageModal.js
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { Info, Plus, Minus } from "lucide-react";
 import { getRiskManagerWithSigner } from "../../lib/riskManager";
+import { getPoolManagerWithSigner } from "../../lib/poolManager";
 import {
   getCapitalPoolWithSigner,
   getUnderlyingAssetAddress,
@@ -75,7 +76,7 @@ export default function ManageCoverageModal({
       let tx;
       if (type === "coverage") {
         if (!policyId) throw new Error("policyId required");
-        const rm = await getRiskManagerWithSigner(depInfo.riskManager);
+        const pm = await getPoolManagerWithSigner(depInfo.poolManager);
 
         const dec = await getUnderlyingAssetDecimals(depInfo.capitalPool);
         const depositBn = ethers.utils.parseUnits(extendCost.toFixed(dec), dec);
@@ -85,17 +86,17 @@ export default function ManageCoverageModal({
         const addr = await token.signer.getAddress();
         const allowance = await token.allowance(
           addr,
-          depInfo.riskManager,
+          depInfo.poolManager,
         );
         if (allowance.lt(depositBn)) {
           const approveTx = await token.approve(
-            depInfo.riskManager,
+            depInfo.poolManager,
             depositBn,
           );
           await approveTx.wait();
         }
 
-        tx = await rm.addPremium(policyId, depositBn);
+        tx = await pm.addPremium(policyId, depositBn);
         await tx.wait();
       } else if (action === "decrease") {
         if (!shares) throw new Error("share info missing");


### PR DESCRIPTION
## Summary
- switch CoverageModal to use PolicyManager for purchasing cover
- switch ManageCoverageModal to top up premiums via PolicyManager
- use PolicyManager in purchase API route
- expand PoolManager ABI with policy management functions

## Testing
- `npm run test` *(fails: Cannot find module 'vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_684ee8d9bfc4832ea416899bfb9773d1