### PR TITLE
Add Hardhat setup script and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ package.json             Project dependencies and scripts
 ## Requirements
 
 - Node.js (>=18)
-- npm
+- npm (>=9)
+- Network access to the npm registry
 
 Install dependencies with:
 
 ```bash
 npm install
 ```
+You can also run Hardhat commands via `scripts/hardhat.sh` which
+automatically installs dependencies if `node_modules` is missing.
 
 ## Usage
 
@@ -84,7 +87,7 @@ npx hardhat run scripts/deploy-oracle.js --network base
 Then update `frontend/.env` using the printed `PriceOracle` and `MulticallReader`
 addresses so the frontend can display token prices and batch queries.
 
-The default network configuration uses Hardhat's in‑memory chain.  Modify `hardhat.config.ts` to add or customise networks.
+The default network configuration uses Hardhat's in‑memory chain.  Modify `hardhat.config.ts` to add or customise networks. Running scripts on a remote network requires access to the configured RPC endpoint.
 
 ## Contracts Overview
 

--- a/scripts/hardhat.sh
+++ b/scripts/hardhat.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run Hardhat commands with automatic dependency installation
+set -e
+if [ ! -d node_modules ]; then
+    echo "Installing npm dependencies..."
+    npm install
+fi
+npx hardhat "$@"
+


### PR DESCRIPTION
## Summary
- add `scripts/hardhat.sh` to automatically install dependencies before running Hardhat
- document Node/NPM requirements and note network access for Hardhat RPC calls

## Testing
- `./scripts/hardhat.sh --version`
- `./scripts/hardhat.sh test` *(fails: couldn't download compiler due to blocked binaries.soliditylang.org)*

------
https://chatgpt.com/codex/tasks/task_e_684ef27ed5a0832e99ebe530f607e570