### PR TITLE
Fix claim coverage update

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -254,8 +254,11 @@ contract RiskManager is Ownable, ReentrancyGuard {
         payoutData.totalCapitalFromPoolLPs = totalCapitalPledged;
         
         capitalPool.executePayout(payoutData);
-        
-        updateCoverageSold(poolId, coverage, false);
+
+        // Update coverage sold directly without going through the PolicyManager
+        // hook to avoid the NotPolicyManager revert when processing claims.
+        poolRegistry.updateCoverageSold(poolId, coverage, false);
+
         policyNFT.burn(_policyId);
     }
     

--- a/test/risk-manager.test.js
+++ b/test/risk-manager.test.js
@@ -562,6 +562,12 @@ describe("RiskManager - processClaim", function () {
     });
 
     describe("Successful Claim - Full Coverage by LPs", function() {
+        it("executes without reverting", async function() {
+            const { riskManager, policyHolder, policyId } = await loadFixture(deployAndClaimFixture);
+            await expect(riskManager.connect(policyHolder).processClaim(policyId, "0x"))
+                .not.to.be.reverted;
+        });
+
         it("should calculate correct net payout and apply losses proportionally to underwriters", async function() {
             const { riskManager, policyHolder, mockCapitalPool, coverageAmount, u1Deposit, u2Deposit, policyId } = await loadFixture(deployAndClaimFixture);
             


### PR DESCRIPTION
## Summary
- update `RiskManager.processClaim` to modify coverage directly on `PoolRegistry`
- test claim execution succeeds without reverting

## Testing
- `npx hardhat test test/risk-manager.test.js` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684ef26cbeb0832ea3a511f12156e638