### PR TITLE
Fix loss realization logic

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -304,12 +304,13 @@ contract RiskManager is Ownable, ReentrancyGuard {
 
     function _realizeLossesForAllPools(address _user) internal {
         uint256[] memory allocations = underwriterAllocations[_user];
+        uint256 originalPledge = underwriterTotalPledge[_user];
         for (uint i = 0; i < allocations.length; i++) {
             uint256 poolId = allocations[i];
             uint256 currentPledge = underwriterTotalPledge[_user];
             if (currentPledge == 0) break;
-            uint256 pendingLoss = lossDistributor.realizeLosses(_user, poolId, currentPledge);
-            if(pendingLoss > 0) {
+            uint256 pendingLoss = lossDistributor.realizeLosses(_user, poolId, originalPledge);
+            if (pendingLoss > 0) {
                 underwriterTotalPledge[_user] -= Math.min(currentPledge, pendingLoss);
                 capitalPool.applyLosses(_user, pendingLoss);
             }


### PR DESCRIPTION
## Summary
- handle loss realization with the original pledge to ensure losses from all pools are realized correctly
- test loss realization across multiple pools

## Testing
- `npx hardhat test` *(fails: couldn't download compiler version)*

------
https://chatgpt.com/codex/tasks/task_e_684ef26e2db8832e892d4f2c6a834ee9