### PR TITLE
Fix yield adapter integration

### DIFF
--- a/frontend/app/config/yieldPlatforms.js
+++ b/frontend/app/config/yieldPlatforms.js
@@ -1,11 +1,12 @@
 export const YieldPlatform = {
-  AAVE: 0,
-  COMPOUND: 1,
-  // COMPOUND: 2,
-  // OTHER_YIELD: 3,
+  NONE: 0,
+  AAVE: 1,
+  COMPOUND: 2,
+  OTHER_YIELD: 3,
 };
 
 export const YIELD_PLATFORM_INFO = {
+  [YieldPlatform.NONE]: { name: 'None', logo: '/placeholder-logo.png' },
   [YieldPlatform.AAVE]: { name: 'Aave', logo: '/images/protocols/aave.png' },
   [YieldPlatform.COMPOUND]: { name: 'Compound', logo: '/images/protocols/compound.png' },
   [YieldPlatform.OTHER_YIELD]: { name: 'Other Yield', logo: '/placeholder-logo.png' },

--- a/frontend/hooks/useYieldAdapters.js
+++ b/frontend/hooks/useYieldAdapters.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { ethers } from 'ethers';
-import { getYieldPlatformInfo } from '../app/config/yieldPlatforms';
+import { YieldPlatform, getYieldPlatformInfo } from '../app/config/yieldPlatforms';
 import { getTokenSymbol } from '../lib/erc20';
 
 export default function useYieldAdapters() {
@@ -13,15 +13,15 @@ export default function useYieldAdapters() {
         if (res.ok) {
           const data = await res.json();
           const decimalsMap = {
-            0: 27, // Aave APR returned with 27 decimals
-            1: 18, // Compound uses 18 decimals
+            [YieldPlatform.AAVE]: 27, // Aave APR returned with 27 decimals
+            [YieldPlatform.COMPOUND]: 18, // Compound uses 18 decimals
           };
 
           const list = await Promise.all(
-            (data.adapters || []).map(async (item, index) => {
+            (data.adapters || []).map(async (item) => {
               let apr = 0;
               try {
-                const decimals = decimalsMap[index] ?? 18;
+                const decimals = decimalsMap[item.id] ?? 18;
                 apr =
                   parseFloat(
                     ethers.utils.formatUnits(item.apr || '0', decimals),
@@ -34,12 +34,12 @@ export default function useYieldAdapters() {
               } catch {}
 
               return {
-                id: index,
+                id: item.id,
                 address: item.address,
                 apr,
                 asset: item.asset,
                 assetSymbol: symbol,
-                ...getYieldPlatformInfo(index),
+                ...getYieldPlatformInfo(item.id),
               };
             }),
           );


### PR DESCRIPTION
## Summary
- align YieldPlatform enum with contracts
- adjust decimals mapping for Aave and Compound adapters
- include adapter IDs when listing adapters via API

## Testing
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684ef59ccf64832e93c491fbf4f46c39