### PR TITLE
Fix PolicyNFT reference in RiskManager

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -61,6 +61,10 @@ interface ILossDistributor {
     function getPendingLosses(address user, uint256 poolId, uint256 userPledge) external view returns (uint256);
 }
 
+interface IPolicyManager {
+    function policyNFT() external view returns (IPolicyNFT);
+}
+
 /**
  * @title RiskManager
  * @author Gemini
@@ -112,17 +116,17 @@ contract RiskManager is Ownable, ReentrancyGuard {
 
     function setAddresses(address _capital, address _registry, address _policy, address _cat, address _loss) external onlyOwner {
         require(
-            _capital != address(0) && 
-            _registry != address(0) && 
-            _policy != address(0) && 
-            _cat != address(0) && 
-            _loss != address(0), 
+            _capital != address(0) &&
+            _registry != address(0) &&
+            _policy != address(0) &&
+            _cat != address(0) &&
+            _loss != address(0),
             "Zero address not allowed"
         );
         capitalPool = ICapitalPool(_capital);
         poolRegistry = IPoolRegistry(_registry);
         policyManager = _policy;
-        policyNFT = IPolicyNFT(Ownable(_policy).owner());
+        policyNFT = IPolicyManager(_policy).policyNFT();
         catPool = ICatInsurancePool(_cat);
         lossDistributor = ILossDistributor(_loss);
         emit AddressesSet(_capital, _registry, _policy, _cat, _loss);

--- a/test/risk-manager.test.js
+++ b/test/risk-manager.test.js
@@ -1142,13 +1142,16 @@ describe("RiskManager - Loss Realization", function() {
         const MockPolicyNFTFactory = await ethers.getContractFactory("MockPolicyNFT");
         const policyNFT = await MockPolicyNFTFactory.deploy(owner.address);
 
+        const PolicyManagerFactory = await ethers.getContractFactory("PolicyManager");
+        const policyManager = await PolicyManagerFactory.deploy(policyNFT.target, owner.address);
+
         const MockCatPoolFactory = await ethers.getContractFactory("MockCatInsurancePool");
         const catPool = await MockCatPoolFactory.deploy(owner.address);
 
         const RiskManagerFactory = await ethers.getContractFactory("RiskManager", owner);
         const riskManager = await RiskManagerFactory.deploy(owner.address);
 
-        await riskManager.setAddresses(capitalPool.target, poolRegistry.target, policyNFT.target, catPool.target, lossDistributor.target);
+        await riskManager.setAddresses(capitalPool.target, poolRegistry.target, policyManager.target, catPool.target, lossDistributor.target);
         await poolRegistry.setRiskManager(riskManager.target);
         await lossDistributor.setRiskManager(riskManager.target);
 


### PR DESCRIPTION
## Summary
- fetch the PolicyNFT address from PolicyManager instead of using the owner
- update tests to deploy a PolicyManager and pass its address to `setAddresses`

## Testing
- `npx hardhat test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684efad343bc832eb505a453d135c506