### PR TITLE
Fix CatPool reward distributor setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The default network configuration uses Hardhat's in‑memory chain.  Modify `har
 - **PolicyManager** – User entrypoint for purchasing cover. Mints and burns `PolicyNFT` tokens.
 - **RiskManager** – Coordinates pool allocations, claims processing and rewards through `LossDistributor` and `RewardDistributor`.
 - **PoolRegistry** – Stores pool parameters, rate models and active adapters for each risk pool.
-- **CatInsurancePool** – Collects a share of premiums and provides additional liquidity during large claims. When linking a `RewardDistributor` to the cat pool, ensure the distributor's `riskManager` is set to the cat pool contract or use the `claimForCatPool` helper function.
+- **CatInsurancePool** – Collects a share of premiums and provides additional liquidity during large claims. Calling `setRewardDistributor` now configures the distributor's cat pool automatically so users can claim protocol asset rewards without extra setup.
 - **Governance (Committee & Staking)** – Simple on‑chain governance used for pausing pools and slashing misbehaving stakers.
 
 ## Running a Local Node

--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -15,6 +15,7 @@ interface IRewardDistributor {
     function claim(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
     function claimForCatPool(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
     function pendingRewards(address user, uint256 poolId, address rewardToken, uint256 userPledge) external view returns (uint256);
+    function setCatPool(address _catPool) external;
 }
 
 contract CatInsurancePool is Ownable, ReentrancyGuard {
@@ -94,6 +95,7 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
     function setRewardDistributor(address _rewardDistributor) external onlyOwner {
         require(_rewardDistributor != address(0), "CIP: Address cannot be zero");
         rewardDistributor = IRewardDistributor(_rewardDistributor);
+        rewardDistributor.setCatPool(address(this));
         emit RewardDistributorSet(_rewardDistributor);
     }
 

--- a/test/CatInsurancePool.test.js
+++ b/test/CatInsurancePool.test.js
@@ -38,7 +38,6 @@ async function deployFixture() {
   const RewardDistributor = await hardhatEthers.getContractFactory("RewardDistributor");
   const rewardDist = await RewardDistributor.deploy(catPool.target);
   await catPool.connect(owner).setRewardDistributor(rewardDist.target);
-  await rewardDist.connect(owner).setCatPool(catPool.target);
   await catPool.connect(owner).setRiskManagerAddress(coverPoolAcc.address);
 
   return { owner, coverPoolAcc, user1, user2, other, usdc, Proto, adapter, catPool, catShare, rewardDist };


### PR DESCRIPTION
## Summary
- configure RewardDistributor cat pool automatically when linking
- document auto setup
- adjust test fixture

## Testing
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684efb5ea064832ea1b21109fdadab42