### PR TITLE
Fix repeated approve in CapitalPool

### DIFF
--- a/contracts/core/CapitalPool.sol
+++ b/contracts/core/CapitalPool.sol
@@ -147,7 +147,7 @@ contract CapitalPool is ReentrancyGuard, Ownable {
         account.totalDepositedAssetPrincipal += _amount;
         account.masterShares += sharesToMint;
         underlyingAsset.safeTransferFrom(msg.sender, address(this), _amount);
-        underlyingAsset.approve(address(chosenAdapter), _amount);
+        underlyingAsset.forceApprove(address(chosenAdapter), _amount);
         chosenAdapter.deposit(_amount);
         totalMasterSharesSystem += sharesToMint;
         totalSystemValue += _amount;


### PR DESCRIPTION
## Summary
- use `forceApprove` for adapter allowances to clear stale approvals

## Testing
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684efb88c1b8832ebae0cb6e4dc4d0f8