### PR TITLE
Improve env var handling for PoolManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ npm run dev
 ```
 
 Environment variables such as the RPC endpoint and deployed contract addresses can
-be configured in `.env` (see `.env.example`). Several API routes under
+be configured in `.env` (see `.env.example`). At a minimum set
+`NEXT_PUBLIC_POOL_MANAGER_ADDRESS` and `NEXT_PUBLIC_RISK_MANAGER_ADDRESS` so the
+frontend knows where the core contracts live. Several API routes under
 `app/api` demonstrate reading data from the contracts. Examples
 include:
 

--- a/frontend/lib/poolManager.ts
+++ b/frontend/lib/poolManager.ts
@@ -4,6 +4,11 @@ import { getProvider } from './provider'
 
 const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_POOL_MANAGER_ADDRESS as string
 
+if (!DEFAULT_ADDRESS) {
+  console.error('\u274C  NEXT_PUBLIC_POOL_MANAGER_ADDRESS env var is missing')
+  throw new Error('NEXT_PUBLIC_POOL_MANAGER_ADDRESS not set')
+}
+
 export function getPoolManager(address: string = DEFAULT_ADDRESS, deployment?: string) {
   return new ethers.Contract(address, PoolManager, getProvider(deployment))
 }


### PR DESCRIPTION
## Summary
- validate `NEXT_PUBLIC_POOL_MANAGER_ADDRESS` when loading the contract
- document required frontend environment variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684efe527374832e99fd8ed38ac48738