### PR TITLE
Fix adapter allowances and secure rewards

### DIFF
--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -68,7 +68,9 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
         
         if (address(_initialAdapter) != address(0)) {
             adapter = _initialAdapter;
-            usdc.approve(address(_initialAdapter), type(uint256).max);
+            // Grant approval to the initial adapter in a controlled manner
+            usdc.safeApprove(address(_initialAdapter), 0);
+            usdc.safeApprove(address(_initialAdapter), type(uint256).max);
         }
     }
 
@@ -106,10 +108,14 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
                 uint256 withdrawnAmount = adapter.withdraw(balanceInOldAdapter, address(this));
                 idleUSDC += withdrawnAmount;
             }
+            // Revoke allowance from the old adapter
+            usdc.safeApprove(address(adapter), 0);
         }
         adapter = IYieldAdapter(_newAdapterAddress);
         if (address(adapter) != address(0)) {
-            usdc.approve(address(adapter), type(uint256).max);
+            // Grant allowance to the new adapter safely
+            usdc.safeApprove(address(adapter), 0);
+            usdc.safeApprove(address(adapter), type(uint256).max);
         }
         emit AdapterChanged(_newAdapterAddress);
     }

--- a/contracts/governance/Committee.sol
+++ b/contracts/governance/Committee.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 
 // Interfaces for other contracts
 interface IRiskManager {
@@ -18,6 +19,7 @@ interface IStakingContract {
 }
 
 contract Committee is Ownable, ReentrancyGuard {
+    using Address for address payable;
 
     /* ───────────────────────── State Variables ──────────────────────── */
 
@@ -215,8 +217,7 @@ contract Committee is Ownable, ReentrancyGuard {
         uint256 userWeight = p.voterWeight[msg.sender];
         userReward += (remainingFees * userWeight) / p.forVotes;
 
-        (bool sent, ) = msg.sender.call{value: userReward}("");
-        require(sent, "Failed to send reward");
+        payable(msg.sender).sendValue(userReward);
         
         emit RewardClaimed(_proposalId, msg.sender, userReward);
     }


### PR DESCRIPTION
## Summary
- reset old adapter allowances when changing yield adapters
- use safeApprove for adapters to avoid unlimited approvals lingering
- use Address.sendValue in `Committee.claimReward`

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684f011166c0832ebbc6623855e80d7c