### PR TITLE
Handle missing oracle feeds

### DIFF
--- a/contracts/oracles/PriceOracle.sol
+++ b/contracts/oracles/PriceOracle.sol
@@ -40,7 +40,9 @@ contract PriceOracle is Ownable {
      */
     function getLatestUsdPrice(address token) public view returns (int256 price, uint8 decimals) {
         AggregatorV3Interface agg = aggregators[token];
-        if (address(agg) == address(0)) revert NoAggregatorConfigured(token);
+        if (address(agg) == address(0)) {
+            return (0, 0);
+        }
         (, price, , , ) = agg.latestRoundData();
         decimals = agg.decimals();
     }
@@ -53,7 +55,7 @@ contract PriceOracle is Ownable {
      */
     function getUsdValue(address token, uint256 amount) external view returns (uint256 value) {
         (int256 price, uint8 feedDecimals) = getLatestUsdPrice(token);
-        require(price > 0, "Invalid price");
+        if (price <= 0) return 0;
         uint8 tokenDecimals = IERC20Metadata(token).decimals();
         uint256 scaledPrice = uint256(price) * (10 ** (18 - feedDecimals));
         value = (amount * scaledPrice) / (10 ** tokenDecimals);

--- a/test/PriceOracle.test.js
+++ b/test/PriceOracle.test.js
@@ -26,4 +26,17 @@ describe("PriceOracle", function () {
     const expected = 100000n * 10n ** 18n; // $100,000 with 18 decimals
     expect(usd).to.equal(expected);
   });
+
+  it("returns zero for unknown tokens", async function () {
+    const { oracle } = await loadFixture(deployFixture);
+    const ERC20 = await ethers.getContractFactory("MockERC20");
+    const Unknown = await ERC20.deploy("Unknown", "UNK", 18);
+
+    const [price, decimals] = await oracle.getLatestUsdPrice(Unknown.target);
+    expect(price).to.equal(0n);
+    expect(decimals).to.equal(0);
+
+    const value = await oracle.getUsdValue(Unknown.target, 1000n);
+    expect(value).to.equal(0n);
+  });
 });


### PR DESCRIPTION
## Summary
- return zero when no Chainlink feed is configured
- prevent revert in getUsdValue
- test PriceOracle with unknown token

## Testing
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684f013f7c78832eb14ad1ba34997273