### PR TITLE
Fix struct override and update allowance pattern

### DIFF
--- a/contracts/core/PolicyManager.sol
+++ b/contracts/core/PolicyManager.sol
@@ -232,12 +232,10 @@ function _settleAndDrainPremium(uint256 _policyId) internal {
         if (catAmount > 0) {
             IERC20 underlying = capitalPool.underlyingAsset();
 
-            // Resolution: Use the safe approval pattern. First, reset the allowance to zero,
-            // then set the new, specific allowance for the transaction.
-            // This leverages the imported SafeERC20 library's safeApprove function.
-            underlying.safeApprove(address(catPool), 0);
-            underlying.safeApprove(address(catPool), catAmount);
-            
+            // Use the OZ forceApprove helper to safely update allowances even when
+            // a non-zero allowance already exists.
+            underlying.forceApprove(address(catPool), catAmount);
+
             catPool.receiveUsdcPremium(catAmount);
         }
         

--- a/contracts/test/MockPolicyNFT.sol
+++ b/contracts/test/MockPolicyNFT.sol
@@ -12,8 +12,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract MockPolicyNFT is Ownable, IPolicyNFT {
 
-    // Mimic the Policy struct from the real contract
-    struct Policy {
+    // Internal struct used for storage. Includes an extra field compared to the
+    // IPolicyNFT.Policy struct to help tests track premium payments.
+    struct PolicyInfo {
         uint256 poolId;
         uint256 coverage;
         uint256 activation;
@@ -26,7 +27,7 @@ contract MockPolicyNFT is Ownable, IPolicyNFT {
 
     // Counter for the next policy token id
     uint256 public nextPolicyId = 1;
-    mapping(uint256 => Policy) public policies;
+    mapping(uint256 => PolicyInfo) public policies;
     mapping(uint256 => address) private _owners; // Internal mapping to mock ownerOf
     // Address of the CoverPool contract that is allowed to mint/burn
     address public coverPoolAddress;
@@ -95,7 +96,7 @@ contract MockPolicyNFT is Ownable, IPolicyNFT {
         uint128 premiumDeposit,
         uint128 lastDrainTime
     ) external {
-        policies[id] = Policy({
+        policies[id] = PolicyInfo({
             poolId: pid,
             coverage: coverage,
             activation: activation,
@@ -133,7 +134,7 @@ contract MockPolicyNFT is Ownable, IPolicyNFT {
         uint128 _lastDrainTime
     ) external override onlyCoverPool returns (uint256) {
         uint256 id = nextPolicyId++;
-        policies[id] = Policy({
+        policies[id] = PolicyInfo({
             poolId: _poolId,
             coverage: _coverage,
             activation: _activation,
@@ -173,8 +174,15 @@ contract MockPolicyNFT is Ownable, IPolicyNFT {
     /**
      * @notice Mocks the getPolicy view function.
      */
-    function getPolicy(uint256 id) external view returns (Policy memory) {
-        return policies[id];
+    function getPolicy(uint256 id) external view returns (IPolicyNFT.Policy memory) {
+        PolicyInfo memory p = policies[id];
+        return IPolicyNFT.Policy({
+            poolId: p.poolId,
+            coverage: p.coverage,
+            activation: p.activation,
+            premiumDeposit: p.premiumDeposit,
+            lastDrainTime: p.lastDrainTime
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix naming collision in `MockPolicyNFT` by introducing a private `PolicyInfo` struct
- return `IPolicyNFT.Policy` from `MockPolicyNFT.getPolicy`
- use `forceApprove` in `PolicyManager` when sending premiums to the CatPool

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684f02d2a310832eaeac5159d24e80b4