### PR TITLE
Fix zero-value event emissions

### DIFF
--- a/contracts/adapters/AaveV3Adapter.sol
+++ b/contracts/adapters/AaveV3Adapter.sol
@@ -97,9 +97,8 @@ contract AaveV3Adapter is IYieldAdapter, Ownable {
 
         if (actuallyWithdrawn > 0) {
             underlyingToken.safeTransfer(_to, actuallyWithdrawn);
+            emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
         }
-        
-        emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
     }
 
     // Owner can set the CapitalPool address

--- a/contracts/adapters/CompoundV3Adapter.sol
+++ b/contracts/adapters/CompoundV3Adapter.sol
@@ -89,9 +89,8 @@ contract CompoundV3Adapter is IYieldAdapter, Ownable, ReentrancyGuard {
 
         if (actuallyWithdrawn > 0) {
             underlyingToken.safeTransfer(_to, actuallyWithdrawn);
+            emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
         }
-        
-        emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
     }
 
     /**

--- a/contracts/adapters/EulerAdapter.sol
+++ b/contracts/adapters/EulerAdapter.sol
@@ -92,8 +92,8 @@ contract EulerV2Adapter is IYieldAdapter, Ownable {
         actuallyWithdrawn = afterBal - beforeBal;
         if (actuallyWithdrawn > 0) {
             underlyingToken.safeTransfer(to, actuallyWithdrawn);
+            emit FundsWithdrawn(to, amount, actuallyWithdrawn);
         }
-        emit FundsWithdrawn(to, amount, actuallyWithdrawn);
     }
 
     function getCurrentValueHeld() external view override returns (uint256) {

--- a/contracts/adapters/MoonwellAdapter.sol
+++ b/contracts/adapters/MoonwellAdapter.sol
@@ -81,9 +81,8 @@ contract MoonwellAdapter is IYieldAdapter, Ownable {
 
         if (actuallyWithdrawn > 0) {
             underlyingToken.safeTransfer(_to, actuallyWithdrawn);
+            emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
         }
-
-        emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
     }
 
     /// @return Current underlying value held by this adapter (liquid + supplied).

--- a/contracts/adapters/MorhpoAdapter.sol
+++ b/contracts/adapters/MorhpoAdapter.sol
@@ -99,9 +99,8 @@ contract MorphoAdapter is IYieldAdapter, Ownable {
 
         if (actuallyWithdrawn > 0) {
             underlyingToken.safeTransfer(_to, actuallyWithdrawn);
+            emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
         }
-
-        emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
     }
 
     /// @notice Current underlying value (liquid + supplied via Morpho)

--- a/contracts/adapters/SdaiAdapter.sol
+++ b/contracts/adapters/SdaiAdapter.sol
@@ -102,9 +102,8 @@ contract SdaiAdapter is IYieldAdapter, Ownable {
         if (actuallyWithdrawn > 0) {
             // Transfer the withdrawn underlyingToken from this adapter to the requested `_to` address.
             underlyingToken.safeTransfer(_to, actuallyWithdrawn);
+            emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
         }
-        
-        emit FundsWithdrawn(_to, _targetAmountOfUnderlyingToWithdraw, actuallyWithdrawn);
         return actuallyWithdrawn;
     }
 

--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -226,7 +226,9 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
                 amountSent += actuallyWithdrawn;
             }
         }
-        emit DrawFromFund(amountToDraw, amountSent);
+        if (amountSent > 0) {
+            emit DrawFromFund(amountToDraw, amountSent);
+        }
     }
 
     function receiveProtocolAssetsForDistribution(address protocolAsset, uint256 amount) external onlyRiskManager nonReentrant {


### PR DESCRIPTION
## Summary
- don't emit DrawFromFund when nothing is drawn
- skip FundsWithdrawn events when adapters withdraw zero

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684f0679c5ec832eaf8db0706ceec894