### PR TITLE
Refactor: extract interfaces

### DIFF
--- a/contracts/adapters/AaveV3Adapter.sol
+++ b/contracts/adapters/AaveV3Adapter.sol
@@ -5,38 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IYieldAdapter.sol";
-
-interface IPoolAddressesProvider {
-    function getPool() external view returns (address);
-}
-
-interface IPool {
-    struct ReserveData {
-        ReserveConfigurationMap configuration;
-        uint128 liquidityIndex;
-        uint128 currentLiquidityRate;
-        uint128 variableBorrowIndex;
-        uint128 currentVariableBorrowRate;
-        uint128 currentStableBorrowRate;
-        uint40 lastUpdateTimestamp;
-        uint16 id;
-        address aTokenAddress;
-        address stableDebtTokenAddress;
-        address variableDebtTokenAddress;
-        address interestRateStrategyAddress;
-        uint128 accruedToTreasury;
-        uint128 unbacked;
-        uint128 isolationModeTotalDebt;
-    }
-
-    struct ReserveConfigurationMap {
-        uint256 data;
-    }
-
-    function getReserveData(address asset) external view returns (ReserveData memory);
-    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
-    function withdraw(address asset, uint256 amount, address to) external returns (uint256);
-}
+import "../interfaces/IPoolAddressesProvider.sol";
+import "../interfaces/IPool.sol";
 
 contract AaveV3Adapter is IYieldAdapter, Ownable {
     using SafeERC20 for IERC20;

--- a/contracts/adapters/CompoundV3Adapter.sol
+++ b/contracts/adapters/CompoundV3Adapter.sol
@@ -6,27 +6,8 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "../interfaces/IYieldAdapter.sol";
-
-// Interfaces for Compound V3
-// CORRECTED: Expanded interface to include necessary functions for value calculation
-interface IComet {
-    function supply(address asset, uint256 amount) external;
-    function withdraw(address asset, uint256 amount) external;
-    function baseToken() external view returns (address);
-    function balanceOf(address account) external view returns (uint256);
-
-    struct UserBasic {
-        int104 principal;
-        uint64 baseTrackingIndex;
-    }
-    function userBasic(address) external view returns (UserBasic memory);
-    function baseSupplyIndex() external view returns (uint256);
-}
-
-interface ICometWithRates is IComet {
-    function getUtilization() external view returns (uint256);
-    function getSupplyRate(uint256 utilization) external view returns (uint256);
-}
+import "../interfaces/IComet.sol";
+import "../interfaces/ICometWithRates.sol";
 
 contract CompoundV3Adapter is IYieldAdapter, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;

--- a/contracts/adapters/EulerAdapter.sol
+++ b/contracts/adapters/EulerAdapter.sol
@@ -5,27 +5,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IYieldAdapter.sol";
-
-/* -------------------------------------------------------------------------- */
-/*                              Euler v2 interfaces                           */
-/* -------------------------------------------------------------------------- */
-
-interface IEulerEToken is IERC20 {
-    function deposit(uint256 subAccountId, uint256 amount) external;
-    function withdraw(uint256 subAccountId, uint256 amount) external;
-    function balanceOfUnderlying(address account) external view returns (uint256);
-}
-
-interface IEulerMarkets {
-    /// per-second borrow & supply rates, 1 × 10-27 (“ray”)
-    function interestRate(address underlying) external view returns (uint256 borrowSPY, uint256 supplySPY);
-}
-
-interface IEulerVault is IERC20 {
-    /* ERC-4626 helpers (not used in APR calc here, but stored for future upgrades) */
-    function convertToAssets(uint256 shares) external view returns (uint256);
-    function totalAssets() external view returns (uint256);
-}
+import "../interfaces/IEulerEToken.sol";
+import "../interfaces/IEulerMarkets.sol";
+import "../interfaces/IEulerVault.sol";
 
 /* -------------------------------------------------------------------------- */
 /*                                Adapter                                     */

--- a/contracts/adapters/MoonwellAdapter.sol
+++ b/contracts/adapters/MoonwellAdapter.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IYieldAdapter.sol";
+import "../interfaces/IMToken.sol";
+import "../interfaces/IMTokenWithRate.sol";
 
 /**
  * @title MoonwellAdapter
@@ -12,16 +14,6 @@ import "../interfaces/IYieldAdapter.sol";
  * @dev  Works with any ERC‑20 market supported by Moonwell, provided the corresponding mToken
  *       (cToken‑like wrapper) is passed to the constructor.  Success codes are 0 just like Compound.
  */
-interface IMToken is IERC20 {
-    function mint(uint256 mintAmount) external returns (uint256);
-    function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
-    function balanceOfUnderlying(address owner) external view returns (uint256);
-}
-
-interface IMTokenWithRate is IMToken {
-    /// Current per-block supply rate, 1e18-scaled (“mantissa”) just like Compound V2
-    function supplyRatePerBlock() external view returns (uint256);
-}
 
 contract MoonwellAdapter is IYieldAdapter, Ownable {
     using SafeERC20 for IERC20;

--- a/contracts/adapters/MorhpoAdapter.sol
+++ b/contracts/adapters/MorhpoAdapter.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IYieldAdapter.sol";
+import "../interfaces/ICometLike.sol";
+import "../interfaces/IMorphoCore.sol";
 
 /**
  * @title MorphoAdapter
@@ -21,17 +23,6 @@ import "../interfaces/IYieldAdapter.sol";
  *         (Comet style). If the pool token lacks `baseToken()`, pass the underlying ERC‑20 directly.
  */
 
-/// @dev Partial interface for a Compound‑v3 Comet (needed only for `baseToken()`)
-interface ICometLike {
-    function baseToken() external view returns (address);
-}
-
-/// @dev Minimal Morpho core interface (Compound‑v3 style)
-interface IMorphoCore {
-    function supply(address poolToken, address onBehalf, uint256 amount) external returns (uint256); // returns shares
-    function withdraw(address poolToken, uint256 amount) external returns (uint256); // returns withdrawn assets
-    function supplyBalanceInOf(address poolToken, address user) external view returns (uint256);
-}
 
 contract MorphoAdapter is IYieldAdapter, Ownable {
     using SafeERC20 for IERC20;

--- a/contracts/core/CapitalPool.sol
+++ b/contracts/core/CapitalPool.sol
@@ -7,14 +7,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-
-// Interface for Yield Adapters
-interface IYieldAdapter {
-    function deposit(uint256 _amount) external;
-    function withdraw(uint256 _amount, address _to) external returns (uint256);
-    function getCurrentValueHeld() external view returns (uint256);
-    function asset() external view returns (IERC20);
-}
+import "../interfaces/IYieldAdapter.sol";
 
 /**
  * @title CapitalPool

--- a/contracts/core/PolicyManager.sol
+++ b/contracts/core/PolicyManager.sol
@@ -7,45 +7,11 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../interfaces/IPolicyNFT.sol";
-
-// --- Interfaces for Protocol Contracts ---
-
-interface IPoolRegistry {
-    struct RateModel {
-        uint256 base;
-        uint256 slope1;
-        uint256 slope2;
-        uint256 kink;
-    }
-    
-    function getPoolData(uint256 _poolId) external view returns (
-        IERC20 protocolTokenToCover,
-        uint256 totalCapitalPledgedToPool,
-        uint256 totalCoverageSold,
-        uint256 capitalPendingWithdrawal,
-        bool isPaused,
-        address feeRecipient
-    );
-    function getPoolRateModel(uint256 _poolId) external view returns (RateModel memory);
-}
-
-interface ICapitalPool {
-    function underlyingAsset() external view returns (IERC20);
-}
-
-
-interface ICatInsurancePool {
-    function receiveUsdcPremium(uint256 amount) external;
-}
-
-interface IRewardDistributor {
-    function distribute(uint256 poolId, address rewardToken, uint256 rewardAmount, uint256 totalPledgeInPool) external;
-}
-
-// A lean interface for the RiskManager
-interface IRiskManager_PM_Hook {
-    function updateCoverageSold(uint256 poolId, uint256 amount, bool isSale) external;
-}
+import "../interfaces/IPoolRegistry.sol";
+import "../interfaces/ICapitalPool.sol";
+import "../interfaces/ICatInsurancePool.sol";
+import "../interfaces/IRewardDistributor.sol";
+import "../interfaces/IRiskManager_PM_Hook.sol";
 
 
 /**

--- a/contracts/core/PoolRegistry.sol
+++ b/contracts/core/PoolRegistry.sol
@@ -3,38 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-/**
- * @title IPoolRegistry
- * @notice The interface for the PoolRegistry contract.
- */
-interface IPoolRegistry {
-    // Re-declaring structs and enums needed in the interface
-    struct RateModel {
-        uint256 base;
-        uint256 slope1;
-        uint256 slope2;
-        uint256 kink;
-    }
-    enum ProtocolRiskIdentifier { NONE, PROTOCOL_A, PROTOCOL_B, LIDO_STETH, ROCKET_RETH }
-
-    function getPoolData(uint256 _poolId) external view returns (
-        IERC20 protocolTokenToCover,
-        uint256 totalCapitalPledgedToPool,
-        uint256 totalCoverageSold,
-        uint256 capitalPendingWithdrawal,
-        bool isPaused,
-        address feeRecipient
-    );
-
-    function getPoolRateModel(uint256 _poolId) external view returns (RateModel memory);
-    
-    // CORRECTED: Added the getPoolPayoutData function back for on-chain use by the RiskManager
-    function getPoolPayoutData(uint256 _poolId) external view returns (address[] memory, uint256[] memory, uint256);
-    
-    function getPoolActiveAdapters(uint256 _poolId) external view returns (address[] memory);
-    function getCapitalPerAdapter(uint256 _poolId, address _adapter) external view returns (uint256);
-}
+import "../interfaces/IPoolRegistry.sol";
 
 /**
  * @title PoolRegistry

--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -6,60 +6,11 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "../interfaces/IPolicyNFT.sol";
-
-// --- Local Interfaces ---
-
-interface IPoolRegistry {
-    enum ProtocolRiskIdentifier { NONE, PROTOCOL_A, PROTOCOL_B, LIDO_STETH, ROCKET_RETH }
-    struct RateModel {
-        uint256 base;
-        uint256 slope1;
-        uint256 slope2;
-        uint256 kink;
-    }
-    function addProtocolRiskPool(address, RateModel calldata, ProtocolRiskIdentifier) external returns (uint256);
-    function updateCapitalAllocation(uint256 poolId, address adapterAddress, uint256 pledgeAmount, bool isAllocation) external;
-    function updateCapitalPendingWithdrawal(uint256 poolId, uint256 amount, bool isRequest) external;
-    function updateCoverageSold(uint256 poolId, uint256 amount, bool isSale) external;
-    function getPoolPayoutData(uint256 poolId) external view returns (address[] memory, uint256[] memory, uint256);
-    function getPoolCount() external view returns (uint256);
-    // CORRECTED: Added missing governance hooks to the interface
-    function setPauseState(uint256 _poolId, bool _isPaused) external;
-    function setFeeRecipient(uint256 _poolId, address _recipient) external;
-}
-
-interface ICapitalPool {
-    struct PayoutData {
-        address claimant;
-        uint256 claimantAmount;
-        address feeRecipient;
-        uint256 feeAmount;
-        address[] adapters;
-        uint256[] capitalPerAdapter;
-        uint256 totalCapitalFromPoolLPs;
-    }
-    function applyLosses(address underwriter, uint256 principalLossAmount) external;
-    function underlyingAsset() external view returns (IERC20);
-    function executePayout(PayoutData calldata payoutData) external;
-    function getUnderwriterAdapterAddress(address underwriter) external view returns (address);
-    function getUnderwriterAccount(address underwriter) external view returns (uint256, uint8, uint256, uint256, uint256);
-    function sharesToValue(uint256 shares) external view returns (uint256);
-}
-
-
-interface ICatInsurancePool {
-    function drawFund(uint256 amount) external;
-}
-
-interface ILossDistributor {
-    function distributeLoss(uint256 poolId, uint256 lossAmount, uint256 totalPledgeInPool) external;
-    function realizeLosses(address user, uint256 poolId, uint256 userPledge) external returns (uint256);
-    function getPendingLosses(address user, uint256 poolId, uint256 userPledge) external view returns (uint256);
-}
-
-interface IPolicyManager {
-    function policyNFT() external view returns (IPolicyNFT);
-}
+import "../interfaces/IPoolRegistry.sol";
+import "../interfaces/ICapitalPool.sol";
+import "../interfaces/ICatInsurancePool.sol";
+import "../interfaces/ILossDistributor.sol";
+import "../interfaces/IPolicyManager.sol";
 
 /**
  * @title RiskManager

--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -8,15 +8,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../tokens/CatShare.sol";
 import "../interfaces/IYieldAdapter.sol";
-
-// Interface for the central Reward Distributor
-interface IRewardDistributor {
-    function distribute(uint256 poolId, address rewardToken, uint256 rewardAmount, uint256 totalPledgeInPool) external;
-    function claim(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
-    function claimForCatPool(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
-    function pendingRewards(address user, uint256 poolId, address rewardToken, uint256 userPledge) external view returns (uint256);
-    function setCatPool(address _catPool) external;
-}
+import "../interfaces/IRewardDistributor.sol";
 
 contract CatInsurancePool is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;

--- a/contracts/governance/Committee.sol
+++ b/contracts/governance/Committee.sol
@@ -5,18 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
-
-// Interfaces for other contracts
-interface IRiskManager {
-    function reportIncident(uint256 _poolId, bool _pauseState) external;
-    function setPoolFeeRecipient(uint256 _poolId, address _recipient) external;
-}
-
-interface IStakingContract {
-    function slash(address _user, uint256 _amount) external;
-    function stakedBalance(address _user) external view returns (uint256);
-    function governanceToken() external view returns (IERC20);
-}
+import "../interfaces/IRiskManager.sol";
+import "../interfaces/IStakingContract.sol";
 
 contract Committee is Ownable, ReentrancyGuard {
     using Address for address payable;

--- a/contracts/interfaces/ICapitalPool.sol
+++ b/contracts/interfaces/ICapitalPool.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ICapitalPool {
+    struct PayoutData {
+        address claimant;
+        uint256 claimantAmount;
+        address feeRecipient;
+        uint256 feeAmount;
+        address[] adapters;
+        uint256[] capitalPerAdapter;
+        uint256 totalCapitalFromPoolLPs;
+    }
+    function applyLosses(address underwriter, uint256 principalLossAmount) external;
+    function underlyingAsset() external view returns (IERC20);
+    function executePayout(PayoutData calldata payoutData) external;
+    function getUnderwriterAdapterAddress(address underwriter) external view returns (address);
+    function getUnderwriterAccount(address underwriter) external view returns (uint256, uint8, uint256, uint256, uint256);
+    function sharesToValue(uint256 shares) external view returns (uint256);
+}

--- a/contracts/interfaces/ICatInsurancePool.sol
+++ b/contracts/interfaces/ICatInsurancePool.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface ICatInsurancePool {
+    function drawFund(uint256 amount) external;
+    function receiveUsdcPremium(uint256 amount) external;
+}

--- a/contracts/interfaces/IComet.sol
+++ b/contracts/interfaces/IComet.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IComet {
+    function supply(address asset, uint256 amount) external;
+    function withdraw(address asset, uint256 amount) external;
+    function baseToken() external view returns (address);
+    function balanceOf(address account) external view returns (uint256);
+
+    struct UserBasic {
+        int104 principal;
+        uint64 baseTrackingIndex;
+    }
+    function userBasic(address) external view returns (UserBasic memory);
+    function baseSupplyIndex() external view returns (uint256);
+}

--- a/contracts/interfaces/ICometLike.sol
+++ b/contracts/interfaces/ICometLike.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface ICometLike {
+    function baseToken() external view returns (address);
+}

--- a/contracts/interfaces/ICometWithRates.sol
+++ b/contracts/interfaces/ICometWithRates.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "./IComet.sol";
+
+interface ICometWithRates is IComet {
+    function getUtilization() external view returns (uint256);
+    function getSupplyRate(uint256 utilization) external view returns (uint256);
+}

--- a/contracts/interfaces/IEulerEToken.sol
+++ b/contracts/interfaces/IEulerEToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IEulerEToken is IERC20 {
+    function deposit(uint256 subAccountId, uint256 amount) external;
+    function withdraw(uint256 subAccountId, uint256 amount) external;
+    function balanceOfUnderlying(address account) external view returns (uint256);
+}

--- a/contracts/interfaces/IEulerMarkets.sol
+++ b/contracts/interfaces/IEulerMarkets.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IEulerMarkets {
+    function interestRate(address underlying) external view returns (uint256 borrowSPY, uint256 supplySPY);
+}

--- a/contracts/interfaces/IEulerVault.sol
+++ b/contracts/interfaces/IEulerVault.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IEulerVault is IERC20 {
+    function convertToAssets(uint256 shares) external view returns (uint256);
+    function totalAssets() external view returns (uint256);
+}

--- a/contracts/interfaces/ILossDistributor.sol
+++ b/contracts/interfaces/ILossDistributor.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface ILossDistributor {
+    function distributeLoss(uint256 poolId, uint256 lossAmount, uint256 totalPledgeInPool) external;
+    function realizeLosses(address user, uint256 poolId, uint256 userPledge) external returns (uint256);
+    function getPendingLosses(address user, uint256 poolId, uint256 userPledge) external view returns (uint256);
+}

--- a/contracts/interfaces/IMToken.sol
+++ b/contracts/interfaces/IMToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMToken is IERC20 {
+    function mint(uint256 mintAmount) external returns (uint256);
+    function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
+    function balanceOfUnderlying(address owner) external view returns (uint256);
+}

--- a/contracts/interfaces/IMTokenWithRate.sol
+++ b/contracts/interfaces/IMTokenWithRate.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "./IMToken.sol";
+
+interface IMTokenWithRate is IMToken {
+    function supplyRatePerBlock() external view returns (uint256);
+}

--- a/contracts/interfaces/IMorphoCore.sol
+++ b/contracts/interfaces/IMorphoCore.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IMorphoCore {
+    function supply(address poolToken, address onBehalf, uint256 amount) external returns (uint256);
+    function withdraw(address poolToken, uint256 amount) external returns (uint256);
+    function supplyBalanceInOf(address poolToken, address user) external view returns (uint256);
+}

--- a/contracts/interfaces/IPolicyManager.sol
+++ b/contracts/interfaces/IPolicyManager.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "./IPolicyNFT.sol";
+
+interface IPolicyManager {
+    function policyNFT() external view returns (IPolicyNFT);
+}

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IPool {
+    struct ReserveData {
+        ReserveConfigurationMap configuration;
+        uint128 liquidityIndex;
+        uint128 currentLiquidityRate;
+        uint128 variableBorrowIndex;
+        uint128 currentVariableBorrowRate;
+        uint128 currentStableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        uint16 id;
+        address aTokenAddress;
+        address stableDebtTokenAddress;
+        address variableDebtTokenAddress;
+        address interestRateStrategyAddress;
+        uint128 accruedToTreasury;
+        uint128 unbacked;
+        uint128 isolationModeTotalDebt;
+    }
+
+    struct ReserveConfigurationMap {
+        uint256 data;
+    }
+
+    function getReserveData(address asset) external view returns (ReserveData memory);
+    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+    function withdraw(address asset, uint256 amount, address to) external returns (uint256);
+}

--- a/contracts/interfaces/IPoolAddressesProvider.sol
+++ b/contracts/interfaces/IPoolAddressesProvider.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IPoolAddressesProvider {
+    function getPool() external view returns (address);
+}

--- a/contracts/interfaces/IPoolRegistry.sol
+++ b/contracts/interfaces/IPoolRegistry.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IPoolRegistry {
+    struct RateModel {
+        uint256 base;
+        uint256 slope1;
+        uint256 slope2;
+        uint256 kink;
+    }
+    enum ProtocolRiskIdentifier { NONE, PROTOCOL_A, PROTOCOL_B, LIDO_STETH, ROCKET_RETH }
+
+    function getPoolData(uint256 _poolId) external view returns (
+        IERC20 protocolTokenToCover,
+        uint256 totalCapitalPledgedToPool,
+        uint256 totalCoverageSold,
+        uint256 capitalPendingWithdrawal,
+        bool isPaused,
+        address feeRecipient
+    );
+
+    function getPoolRateModel(uint256 _poolId) external view returns (RateModel memory);
+    function getPoolPayoutData(uint256 _poolId) external view returns (address[] memory, uint256[] memory, uint256);
+    function getPoolActiveAdapters(uint256 _poolId) external view returns (address[] memory);
+    function getCapitalPerAdapter(uint256 _poolId, address _adapter) external view returns (uint256);
+    function addProtocolRiskPool(address, RateModel calldata, ProtocolRiskIdentifier) external returns (uint256);
+    function updateCapitalAllocation(uint256 poolId, address adapterAddress, uint256 pledgeAmount, bool isAllocation) external;
+    function updateCapitalPendingWithdrawal(uint256 poolId, uint256 amount, bool isRequest) external;
+    function updateCoverageSold(uint256 poolId, uint256 amount, bool isSale) external;
+    function getPoolCount() external view returns (uint256);
+    function setPauseState(uint256 _poolId, bool _isPaused) external;
+    function setFeeRecipient(uint256 _poolId, address _recipient) external;
+}

--- a/contracts/interfaces/IRewardDistributor.sol
+++ b/contracts/interfaces/IRewardDistributor.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IRewardDistributor {
+    function distribute(uint256 poolId, address rewardToken, uint256 rewardAmount, uint256 totalPledgeInPool) external;
+    function claim(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
+    function claimForCatPool(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
+    function updateUserState(address user, uint256 poolId, address rewardToken, uint256 userPledge) external;
+    function pendingRewards(address user, uint256 poolId, address rewardToken, uint256 userPledge) external view returns (uint256);
+    function setCatPool(address _catPool) external;
+}

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IRiskManager {
+    function reportIncident(uint256 _poolId, bool _pauseState) external;
+    function setPoolFeeRecipient(uint256 _poolId, address _recipient) external;
+}

--- a/contracts/interfaces/IRiskManager_PM_Hook.sol
+++ b/contracts/interfaces/IRiskManager_PM_Hook.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IRiskManager_PM_Hook {
+    function updateCoverageSold(uint256 poolId, uint256 amount, bool isSale) external;
+}

--- a/contracts/interfaces/IStakingContract.sol
+++ b/contracts/interfaces/IStakingContract.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IStakingContract {
+    function slash(address _user, uint256 _amount) external;
+    function stakedBalance(address _user) external view returns (uint256);
+    function governanceToken() external view returns (IERC20);
+}

--- a/contracts/test/IMintableERC20.sol
+++ b/contracts/test/IMintableERC20.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMintableERC20 is IERC20 {
+    function mint(address to, uint256 amount) external;
+    function burnFrom(address account, uint256 amount) external;
+}

--- a/contracts/test/MockAaveV3Pool.sol
+++ b/contracts/test/MockAaveV3Pool.sol
@@ -4,11 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./MockERC20.sol";
-
-interface IMintableERC20 is IERC20 {
-    function mint(address to, uint256 amount) external;
-    function burnFrom(address account, uint256 amount) external;
-}
+import "./IMintableERC20.sol";
 
 /// @title Mock Aave V3 Pool
 /// @notice Minimal mock of the Aave V3 pool for adapter testing

--- a/contracts/utils/LossDistributor.sol
+++ b/contracts/utils/LossDistributor.sol
@@ -2,16 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-/**
- * @title ILossDistributor
- * @notice Interface for the LossDistributor contract.
- */
-interface ILossDistributor {
-    function distributeLoss(uint256 poolId, uint256 lossAmount, uint256 totalPledgeInPool) external;
-    function realizeLosses(address user, uint256 poolId, uint256 userPledge) external returns (uint256);
-    function getPendingLosses(address user, uint256 poolId, uint256 userPledge) external view returns (uint256);
-}
+import "../interfaces/ILossDistributor.sol";
 
 /**
  * @title LossDistributor

--- a/contracts/utils/RewardDistributor.sol
+++ b/contracts/utils/RewardDistributor.sol
@@ -4,18 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-/**
- * @title IRewardDistributor
- * @notice Interface for the RewardDistributor contract.
- */
-interface IRewardDistributor {
-    function distribute(uint256 poolId, address rewardToken, uint256 rewardAmount, uint256 totalPledgeInPool) external;
-    function claim(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
-    function claimForCatPool(address user, uint256 poolId, address rewardToken, uint256 userPledge) external returns (uint256);
-    function updateUserState(address user, uint256 poolId, address rewardToken, uint256 userPledge) external;
-    function pendingRewards(address user, uint256 poolId, address rewardToken, uint256 userPledge) external view returns (uint256);
-}
+import "../interfaces/IRewardDistributor.sol";
 
 /**
  * @title RewardDistributor


### PR DESCRIPTION
## Summary
- move interface definitions to new files under `contracts/interfaces`
- update all contracts to import the new interfaces
- clean up test mock to use new IMintableERC20 interface

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684f0a0f0858832e92db9268deffba1f