### PR TITLE
Fix compile errors in PoolRegistry, RiskManager, CatInsurancePool

### DIFF
--- a/contracts/core/PoolRegistry.sol
+++ b/contracts/core/PoolRegistry.sol
@@ -99,7 +99,7 @@ contract PoolRegistry is IPoolRegistry, Ownable {
         }
     }
 
-    function updatePoolPauseState(uint256 _poolId, bool _isPaused) external onlyRiskManager {
+    function setPauseState(uint256 _poolId, bool _isPaused) external onlyRiskManager {
         PoolData storage pool = protocolRiskPools[_poolId];
         pool.isPaused = _isPaused;
         pool.pauseTimestamp = _isPaused ? block.timestamp : 0;

--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -182,7 +182,9 @@ contract RiskManager is Ownable, ReentrancyGuard {
     /* ───────────────────── Claim Processing ───────────────────── */
 
     function processClaim(uint256 _policyId) external nonReentrant {
-        (uint256 poolId, uint256 coverage, , ,) = policyNFT.getPolicy(_policyId);
+        IPolicyNFT.Policy memory policy = policyNFT.getPolicy(_policyId);
+        uint256 poolId = policy.poolId;
+        uint256 coverage = policy.coverage;
         (address[] memory adapters, uint256[] memory capitalPerAdapter, uint256 totalCapitalPledged) = poolRegistry.getPoolPayoutData(poolId);
         
         lossDistributor.distributeLoss(poolId, coverage, totalCapitalPledged);

--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -61,8 +61,8 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
         if (address(_initialAdapter) != address(0)) {
             adapter = _initialAdapter;
             // Grant approval to the initial adapter in a controlled manner
-            usdc.safeApprove(address(_initialAdapter), 0);
-            usdc.safeApprove(address(_initialAdapter), type(uint256).max);
+            usdc.forceApprove(address(_initialAdapter), 0);
+            usdc.forceApprove(address(_initialAdapter), type(uint256).max);
         }
     }
 
@@ -101,13 +101,13 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
                 idleUSDC += withdrawnAmount;
             }
             // Revoke allowance from the old adapter
-            usdc.safeApprove(address(adapter), 0);
+            usdc.forceApprove(address(adapter), 0);
         }
         adapter = IYieldAdapter(_newAdapterAddress);
         if (address(adapter) != address(0)) {
             // Grant allowance to the new adapter safely
-            usdc.safeApprove(address(adapter), 0);
-            usdc.safeApprove(address(adapter), type(uint256).max);
+            usdc.forceApprove(address(adapter), 0);
+            usdc.forceApprove(address(adapter), type(uint256).max);
         }
         emit AdapterChanged(_newAdapterAddress);
     }


### PR DESCRIPTION
## Summary
- implement `setPauseState` in `PoolRegistry`
- fix `processClaim` struct usage in `RiskManager`
- use `forceApprove` in `CatInsurancePool`

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler version list)*
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ad8052c832e8b74eaf3f3edeed8