### PR TITLE
Fix missing functions reference

### DIFF
--- a/contracts/test/ReentrancyAttacker.sol
+++ b/contracts/test/ReentrancyAttacker.sol
@@ -21,13 +21,16 @@ contract ReentrancyAttacker {
         riskManager.allocateCapital(poolIds);
     }
 
-    function beginAttack(uint256 poolId) external {
-        riskManager.claimPremiumRewards(poolId);
-        riskManager.claimPremiumRewards(poolId);
+    // The RiskManager contract no longer exposes reward claiming functions in
+    // the current version of the protocol. These attack helpers previously
+    // attempted to call `claimPremiumRewards` and `claimDistressedAssets` twice
+    // to verify the `nonReentrant` modifier. They are retained as no-op
+    // functions to keep older tests compiling.
+    function beginAttack(uint256 poolId) external pure {
+        revert("claimPremiumRewards removed");
     }
 
-    function beginDistressedAssetAttack(uint256 poolId) external {
-        riskManager.claimDistressedAssets(poolId);
-        riskManager.claimDistressedAssets(poolId);
+    function beginDistressedAssetAttack(uint256 poolId) external pure {
+        revert("claimDistressedAssets removed");
     }
 }


### PR DESCRIPTION
## Summary
- remove outdated reward claim calls from `ReentrancyAttacker`

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684f1d0a4bf4832e8d987308bc8c9605