### PR TITLE
Fix MockERC20 deployment in CatInsurancePool tests

### DIFF
--- a/test/CatInsurancePool.test.js
+++ b/test/CatInsurancePool.test.js
@@ -32,8 +32,10 @@ describe("CatInsurancePool", function () {
 
         // --- Deploy Mocks ---
         const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", ethers.parseUnits("1000000", 6));
-        mockRewardToken = await MockERC20Factory.deploy("Reward Token", "RWT", ethers.parseUnits("1000000", 18));
+        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+        await mockUsdc.mint(owner.address, ethers.parseUnits("1000000", 6));
+        mockRewardToken = await MockERC20Factory.deploy("Reward Token", "RWT", 18);
+        await mockRewardToken.mint(owner.address, ethers.parseUnits("1000000", 18));
         
         mockAdapter = await deployMock(iYieldAdapterAbi, owner);
         mockRewardDistributor = await deployMock(iRewardDistributorAbi, owner);


### PR DESCRIPTION
## Summary
- correct MockERC20 constructor params in CatInsurancePool test
- mint tokens after deployment so LPs can receive funds

## Testing
- `npx hardhat test test/CatInsurancePool.test.js` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684f20525c0c832eb6eee19ed93c785a