### PR TITLE
Remove forceApprove usage

### DIFF
--- a/contracts/core/CapitalPool.sol
+++ b/contracts/core/CapitalPool.sol
@@ -139,7 +139,7 @@ contract CapitalPool is ReentrancyGuard, Ownable {
         account.totalDepositedAssetPrincipal += _amount;
         account.masterShares += sharesToMint;
         underlyingAsset.safeTransferFrom(msg.sender, address(this), _amount);
-        underlyingAsset.forceApprove(address(chosenAdapter), _amount);
+        underlyingAsset.approve(address(chosenAdapter), _amount);
         chosenAdapter.deposit(_amount);
         totalMasterSharesSystem += sharesToMint;
         totalSystemValue += _amount;

--- a/contracts/core/PolicyManager.sol
+++ b/contracts/core/PolicyManager.sol
@@ -185,9 +185,8 @@ function _settleAndDrainPremium(uint256 _policyId) internal {
         if (catAmount > 0) {
             IERC20 underlying = capitalPool.underlyingAsset();
 
-            // Use the OZ forceApprove helper to safely update allowances even when
-            // a non-zero allowance already exists.
-            underlying.forceApprove(address(catPool), catAmount);
+            // Approve the Cat Pool to pull the premium amount
+            underlying.approve(address(catPool), catAmount);
 
             catPool.receiveUsdcPremium(catAmount);
         }

--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -60,9 +60,9 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
         
         if (address(_initialAdapter) != address(0)) {
             adapter = _initialAdapter;
-            // Grant approval to the initial adapter in a controlled manner
-            usdc.forceApprove(address(_initialAdapter), 0);
-            usdc.forceApprove(address(_initialAdapter), type(uint256).max);
+            // Grant approval to the initial adapter
+            usdc.approve(address(_initialAdapter), 0);
+            usdc.approve(address(_initialAdapter), type(uint256).max);
         }
     }
 
@@ -101,13 +101,13 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
                 idleUSDC += withdrawnAmount;
             }
             // Revoke allowance from the old adapter
-            usdc.forceApprove(address(adapter), 0);
+            usdc.approve(address(adapter), 0);
         }
         adapter = IYieldAdapter(_newAdapterAddress);
         if (address(adapter) != address(0)) {
-            // Grant allowance to the new adapter safely
-            usdc.forceApprove(address(adapter), 0);
-            usdc.forceApprove(address(adapter), type(uint256).max);
+            // Grant allowance to the new adapter
+            usdc.approve(address(adapter), 0);
+            usdc.approve(address(adapter), type(uint256).max);
         }
         emit AdapterChanged(_newAdapterAddress);
     }


### PR DESCRIPTION
## Summary
- use standard `approve` instead of `forceApprove`

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler)*
- `npx hardhat test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684fe4ba2b60832eadeb1f24d2ac982f