### PR TITLE
Update middleware config for contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,13 @@ npm run dev
 ```
 
 Environment variables such as the RPC endpoint and deployed contract addresses can
-be configured in `.env` (see `.env.example`). At a minimum set
+be configured in `.env` (see `.env.example`). If no addresses are provided the
+frontend attempts to read `deployedAddresses.json` at the repository root,
+written by the deployment scripts. At a minimum set
 `NEXT_PUBLIC_POOL_MANAGER_ADDRESS` and `NEXT_PUBLIC_RISK_MANAGER_ADDRESS` so the
-frontend knows where the core contracts live. Several API routes under
-`app/api` demonstrate reading data from the contracts. Examples
+frontend knows where the core contracts live when no JSON file is present.
+Several API routes under `app/api` demonstrate reading data from the contracts.
+Examples
 include:
 
 - `GET /api/pools` – number of pools

--- a/frontend/app/config/deployments.js
+++ b/frontend/app/config/deployments.js
@@ -10,6 +10,34 @@ if (raw) {
 }
 
 if (!deployments.length) {
+  try {
+    // Fallback to addresses written by the deploy scripts
+    const fs = require('fs');
+    const path = require('path');
+    const file = path.join(process.cwd(), '..', 'deployedAddresses.json');
+    if (fs.existsSync(file)) {
+      const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+      deployments = [
+        {
+          name: 'default',
+          riskManager: json.RiskManager,
+          capitalPool: json.CapitalPool,
+          catPool: json.CatInsurancePool,
+          poolRegistry: json.PoolRegistry,
+          poolManager: json.PolicyManager,
+          priceOracle: json.PriceOracle,
+          multicallReader: json.MulticallReader,
+          lossDistributor: json.LossDistributor,
+          rewardDistributor: json.RewardDistributor,
+        },
+      ];
+    }
+  } catch (err) {
+    console.error('Failed to load deployedAddresses.json', err);
+  }
+}
+
+if (!deployments.length) {
   deployments = [
     {
       name: 'default',


### PR DESCRIPTION
## Summary
- load deployed contract addresses automatically
- document deployedAddresses.json fallback

## Testing
- `npm test` *(fails: no test specified)*
- `npx hardhat test` *(fails to download compiler due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68503f5f6f08832ea4469e6571f6a676