### PR TITLE
Update deployment scripts for new CatInsurancePool

### DIFF
--- a/scripts/deploy-usdc.js
+++ b/scripts/deploy-usdc.js
@@ -62,9 +62,16 @@ async function main() {
   const policyManager = await PolicyManager.deploy(policyNFT.target, deployer.address);
   await policyManager.waitForDeployment();
 
+  const CatShare = await ethers.getContractFactory("CatShare");
+  const catShare = await CatShare.deploy();
+  await catShare.waitForDeployment();
+
   const CatInsurancePool = await ethers.getContractFactory("CatInsurancePool");
-  const catPool = await CatInsurancePool.deploy(USDC_ADDRESS, "0x0000000000000000000000000000000000000000", deployer.address);
+  const catPool = await CatInsurancePool.deploy(USDC_ADDRESS, catShare.target, ethers.ZeroAddress, deployer.address);
   await catPool.waitForDeployment();
+
+  await catShare.transferOwnership(catPool.target);
+  await catPool.initialize();
 
   const CapitalPool = await ethers.getContractFactory("CapitalPool");
   const capitalPool = await CapitalPool.deploy(deployer.address, USDC_ADDRESS);

--- a/scripts/deploy-weth.js
+++ b/scripts/deploy-weth.js
@@ -62,9 +62,16 @@ async function main() {
   const policyManager = await PolicyManager.deploy(policyNFT.target, deployer.address);
   await policyManager.waitForDeployment();
 
+  const CatShare = await ethers.getContractFactory("CatShare");
+  const catShare = await CatShare.deploy();
+  await catShare.waitForDeployment();
+
   const CatInsurancePool = await ethers.getContractFactory("CatInsurancePool");
-  const catPool = await CatInsurancePool.deploy(WETH_ADDRESS, ethers.ZeroAddress, deployer.address);
+  const catPool = await CatInsurancePool.deploy(WETH_ADDRESS, catShare.target, ethers.ZeroAddress, deployer.address);
   await catPool.waitForDeployment();
+
+  await catShare.transferOwnership(catPool.target);
+  await catPool.initialize();
 
   const CapitalPool = await ethers.getContractFactory("CapitalPool");
   const capitalPool = await CapitalPool.deploy(deployer.address, WETH_ADDRESS);


### PR DESCRIPTION
## Summary
- add CatShare deployment and initialization
- update CatInsurancePool constructor parameters
- transfer CatShare ownership to pool and call initialize

## Testing
- `npx hardhat test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6850416c1188832e853ce2af1fd83e5e