### PR TITLE
Fix share ownership timing before pool initialization

### DIFF
--- a/scripts/deploy-usdc.js
+++ b/scripts/deploy-usdc.js
@@ -70,7 +70,8 @@ async function main() {
   const catPool = await CatInsurancePool.deploy(USDC_ADDRESS, catShare.target, ethers.ZeroAddress, deployer.address);
   await catPool.waitForDeployment();
 
-  await catShare.transferOwnership(catPool.target);
+  const transferTx = await catShare.transferOwnership(catPool.target);
+  await transferTx.wait();
   await catPool.initialize();
 
   const CapitalPool = await ethers.getContractFactory("CapitalPool");


### PR DESCRIPTION
## Summary
- ensure CatInsurancePool owns CatShare before initialization

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68504451b5c4832eae42e296e09907e4