### PR TITLE
Fix Provide Coverage wallet balance

### DIFF
--- a/frontend/app/components/UnderwriterPanel.js
+++ b/frontend/app/components/UnderwriterPanel.js
@@ -92,6 +92,7 @@ export default function UnderwriterPanel({ displayCurrency }) {
           ),
         ),
         price: pool.tokenPriceUsd ?? 0,
+        deployment: pool.deployment,
       })
       return acc
     }, {})
@@ -497,6 +498,14 @@ export default function UnderwriterPanel({ displayCurrency }) {
           yield={totalYield}
           yieldChoice={selectedYield}
           poolIds={selectedMarkets}
+          deployment={
+            selectedMarkets.length > 0
+              ? markets
+                  .find((m) => m.id === selectedMarkets[0])
+                  ?.pools.find((p) => p.token === selectedToken?.symbol)
+                  ?.deployment
+              : undefined
+          }
           selectedMarkets={selectedMarkets.map((id) => {
             const market = markets.find((m) => m.id === id)
             const pool = market?.pools.find((p) => p.token === selectedToken?.symbol)


### PR DESCRIPTION
## Summary
- pass deployment info into UnderwriterPanel's CoverageModal
- store deployment on markets data to fetch balances correctly

## Testing
- `npm test --prefix frontend` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_685154ed8768832eba4b6851b8b07cf1