### PR TITLE
Fix reserve config display on pool page

### DIFF
--- a/frontend/app/pool/[protocol]/[token]/page.js
+++ b/frontend/app/pool/[protocol]/[token]/page.js
@@ -85,7 +85,7 @@ export default function PoolDetailsPage() {
   const [purchaseModalOpen, setPurchaseModalOpen] = useState(false)
   const [provideModalOpen, setProvideModalOpen] = useState(false)
 
-  const { config: reserveConfig } = useReserveConfig()
+  const { config: reserveConfig } = useReserveConfig(pool?.deployment)
 
   const premiumCanvasRef = useRef(null)
   const utilCanvasRef = useRef(null)


### PR DESCRIPTION
## Summary
- fix reserve config retrieval by querying contracts directly
- pass pool deployment to useReserveConfig hook

## Testing
- `npm install --prefix frontend` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_685154d5ab80832e9e697c2180f148fe