### PR TITLE
Use config file for contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,10 @@ Environment variables such as the RPC endpoint and contract addresses are
 configured in `.env` (see `.env.example`). Address resolution happens inside
 `frontend/app/config/deployments.js` in the following order:
 
-1. `NEXT_PUBLIC_DEPLOYMENTS` – if set, this JSON array describes one or more
-   deployments and their contract addresses.
-2. `deployedAddresses.json` – when the environment variable is missing the
-   file written by the Hardhat deploy scripts is loaded from the repository
-   root.
+1. `deployedAddresses.json` – the file written by the Hardhat deploy scripts in
+   the repository root. This is loaded first when present.
+2. `NEXT_PUBLIC_DEPLOYMENTS` – optional environment variable containing a JSON
+   array of deployments which overrides the config file.
 3. Individual address variables such as `NEXT_PUBLIC_RISK_MANAGER_ADDRESS` –
    used when neither of the above sources are present.
 

--- a/frontend/app/config/deployments.js
+++ b/frontend/app/config/deployments.js
@@ -1,43 +1,43 @@
-const raw = process.env.NEXT_PUBLIC_DEPLOYMENTS;
 let deployments = [];
 
-if (raw) {
-  try {
-    deployments = JSON.parse(raw);
-  } catch (err) {
-    console.error('Failed to parse NEXT_PUBLIC_DEPLOYMENTS', err);
+try {
+  // Primary config file written by the deploy scripts
+  const fs = require('fs');
+  const path = require('path');
+  const file = path.join(process.cwd(), '..', 'deployedAddresses.json');
+  if (fs.existsSync(file)) {
+    const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+    deployments = [
+      {
+        name: 'default',
+        riskManager: json.RiskManager,
+        capitalPool: json.CapitalPool,
+        catPool: json.CatInsurancePool,
+        poolRegistry: json.PoolRegistry,
+        poolManager: json.PolicyManager,
+        priceOracle: json.PriceOracle,
+        multicallReader: json.MulticallReader,
+        lossDistributor: json.LossDistributor,
+        rewardDistributor: json.RewardDistributor,
+        policyNft: json.PolicyNFT,
+        staking: json.StakingContract,
+        committee: json.Committee,
+        governanceToken: json.GovernanceToken,
+      },
+    ];
   }
+} catch (err) {
+  console.error('Failed to load deployedAddresses.json', err);
 }
 
 if (!deployments.length) {
-  try {
-    // Fallback to addresses written by the deploy scripts
-    const fs = require('fs');
-    const path = require('path');
-    const file = path.join(process.cwd(), '..', 'deployedAddresses.json');
-    if (fs.existsSync(file)) {
-      const json = JSON.parse(fs.readFileSync(file, 'utf8'));
-      deployments = [
-        {
-          name: 'default',
-          riskManager: json.RiskManager,
-          capitalPool: json.CapitalPool,
-          catPool: json.CatInsurancePool,
-          poolRegistry: json.PoolRegistry,
-          poolManager: json.PolicyManager,
-          priceOracle: json.PriceOracle,
-          multicallReader: json.MulticallReader,
-          lossDistributor: json.LossDistributor,
-          rewardDistributor: json.RewardDistributor,
-          policyNft: json.PolicyNFT,
-          staking: json.StakingContract,
-          committee: json.Committee,
-          governanceToken: json.GovernanceToken,
-        },
-      ];
+  const raw = process.env.NEXT_PUBLIC_DEPLOYMENTS;
+  if (raw) {
+    try {
+      deployments = JSON.parse(raw);
+    } catch (err) {
+      console.error('Failed to parse NEXT_PUBLIC_DEPLOYMENTS', err);
     }
-  } catch (err) {
-    console.error('Failed to load deployedAddresses.json', err);
   }
 }
 

--- a/scripts/deploy-governance.js
+++ b/scripts/deploy-governance.js
@@ -68,6 +68,14 @@ async function main() {
   const outPath = path.join(__dirname, "..", "governance_deployedAddresses.json");
   fs.writeFileSync(outPath, JSON.stringify(addresses, null, 2));
   console.log(`Saved addresses to ${outPath}`);
+
+  const rootPath = path.join(__dirname, "..", "deployedAddresses.json");
+  let root = {};
+  if (fs.existsSync(rootPath)) {
+    root = JSON.parse(fs.readFileSync(rootPath, "utf8"));
+  }
+  fs.writeFileSync(rootPath, JSON.stringify({ ...root, ...addresses }, null, 2));
+  console.log(`Updated ${rootPath}`);
 }
 
 main().catch((err) => {

--- a/scripts/deploy-oracle.js
+++ b/scripts/deploy-oracle.js
@@ -42,6 +42,14 @@ async function main() {
   addresses.PriceOracle = oracle.target
   fs.writeFileSync(addressesPath, JSON.stringify(addresses, null, 2))
   console.log(`Saved addresses to ${addressesPath}`)
+
+  const rootPath = path.join(__dirname, "..", "deployedAddresses.json")
+  let root = {}
+  if (fs.existsSync(rootPath)) {
+    root = JSON.parse(fs.readFileSync(rootPath, "utf8"))
+  }
+  fs.writeFileSync(rootPath, JSON.stringify({ ...root, ...addresses }, null, 2))
+  console.log(`Updated ${rootPath}`)
 }
 
 main().catch((err) => {

--- a/scripts/deploy-usdc.js
+++ b/scripts/deploy-usdc.js
@@ -154,6 +154,14 @@ async function main() {
   const outPath = path.join(__dirname, "..", "usdc_deployedAddresses.json");
   fs.writeFileSync(outPath, JSON.stringify(addresses, null, 2));
   console.log(`Saved addresses to ${outPath}`);
+
+  const rootPath = path.join(__dirname, "..", "deployedAddresses.json");
+  let root = {};
+  if (fs.existsSync(rootPath)) {
+    root = JSON.parse(fs.readFileSync(rootPath, "utf8"));
+  }
+  fs.writeFileSync(rootPath, JSON.stringify({ ...root, ...addresses }, null, 2));
+  console.log(`Updated ${rootPath}`);
 }
 
 main().catch((err) => {

--- a/scripts/deploy-weth.js
+++ b/scripts/deploy-weth.js
@@ -150,6 +150,14 @@ async function main() {
   const outPath = path.join(__dirname, "..", "weth_deployedAddresses.json");
   fs.writeFileSync(outPath, JSON.stringify(addresses, null, 2));
   console.log(`Saved addresses to ${outPath}`);
+
+  const rootPath = path.join(__dirname, "..", "deployedAddresses.json");
+  let root = {};
+  if (fs.existsSync(rootPath)) {
+    root = JSON.parse(fs.readFileSync(rootPath, "utf8"));
+  }
+  fs.writeFileSync(rootPath, JSON.stringify({ ...root, ...addresses }, null, 2));
+  console.log(`Updated ${rootPath}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- prioritize `deployedAddresses.json` for address lookup
- keep env variables as fallback after the config file
- automatically update `deployedAddresses.json` from all deploy scripts
- document new resolution order in README

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685165163200832e905c8ac4f31044bb