### PR TITLE
Improve API multicall batching

### DIFF
--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getRiskManager } from '../../../lib/riskManager'
 import { getCapitalPool } from '../../../lib/capitalPool'
+import { getMulticallReader } from '../../../lib/multicallReader'
 import deployments from '../../config/deployments'
 
 export async function GET(req: Request) {
@@ -10,12 +11,25 @@ export async function GET(req: Request) {
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
     const rm = getRiskManager(dep.riskManager, dep.name)
     const cp = getCapitalPool(dep.capitalPool, dep.name)
+    const multicall = getMulticallReader(dep.multicallReader, dep.name)
 
-    const [cooldown, claimFee, notice] = await Promise.all([
-      (rm as any).COVER_COOLDOWN_PERIOD(),
-      (rm as any).CLAIM_FEE_BPS(),
-      (cp as any).UNDERWRITER_NOTICE_PERIOD(),
-    ])
+    const calls = [
+      { target: dep.riskManager, callData: rm.interface.encodeFunctionData('COVER_COOLDOWN_PERIOD') },
+      { target: dep.riskManager, callData: rm.interface.encodeFunctionData('CLAIM_FEE_BPS') },
+      { target: dep.capitalPool, callData: cp.interface.encodeFunctionData('UNDERWRITER_NOTICE_PERIOD') },
+    ]
+
+    const res = await multicall.tryAggregate(false, calls)
+
+    const cooldown = res[0].success
+      ? rm.interface.decodeFunctionResult('COVER_COOLDOWN_PERIOD', res[0].returnData)[0]
+      : 0n
+    const claimFee = res[1].success
+      ? rm.interface.decodeFunctionResult('CLAIM_FEE_BPS', res[1].returnData)[0]
+      : 0n
+    const notice = res[2].success
+      ? cp.interface.decodeFunctionResult('UNDERWRITER_NOTICE_PERIOD', res[2].returnData)[0]
+      : 0n
     return NextResponse.json({
       coverCooldownPeriod: cooldown.toString(),
       claimFeeBps: claimFee.toString(),

--- a/frontend/app/api/staking/user/[address]/route.ts
+++ b/frontend/app/api/staking/user/[address]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { getProvider } from '../../../../../lib/provider'
 import { getStaking } from '../../../../../lib/staking'
+import { getMulticallReader } from '../../../../../lib/multicallReader'
 import deployments from '../../../../config/deployments'
 
 export async function GET(req: Request, { params }: { params: { address: string } }) {
@@ -9,11 +9,19 @@ export async function GET(req: Request, { params }: { params: { address: string 
     const depName = url.searchParams.get('deployment')
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
     const staking = getStaking(dep.staking, dep.name)
+    const multicall = getMulticallReader(dep.multicallReader, dep.name)
     const addr = params.address.toLowerCase()
-    const [staked, total] = await Promise.all([
-      staking.stakedBalance(addr),
-      staking.totalStaked(),
-    ])
+    const calls = [
+      { target: dep.staking, callData: staking.interface.encodeFunctionData('stakedBalance', [addr]) },
+      { target: dep.staking, callData: staking.interface.encodeFunctionData('totalStaked') },
+    ]
+    const res = await multicall.tryAggregate(false, calls)
+    const staked = res[0].success
+      ? staking.interface.decodeFunctionResult('stakedBalance', res[0].returnData)[0]
+      : 0n
+    const total = res[1].success
+      ? staking.interface.decodeFunctionResult('totalStaked', res[1].returnData)[0]
+      : 0n
     return NextResponse.json({ address: addr, staked: staked.toString(), totalStaked: total.toString() })
   } catch (err: any) {
     return NextResponse.json({ error: err.message }, { status: 500 })

--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -5,6 +5,7 @@ import { getRiskManager } from '@/lib/riskManager'
 import { getPoolRegistry } from '@/lib/poolRegistry'
 import deployments from '../../../config/deployments'
 import { getLossDistributor } from '@/lib/lossDistributor'
+import { getMulticallReader } from '@/lib/multicallReader'
 
 export async function GET(
   _req: Request,
@@ -21,30 +22,74 @@ export async function GET(
       const rm = getRiskManager(dep.riskManager, dep.name)
       const pr = getPoolRegistry(dep.poolRegistry, dep.name)
       const ld = getLossDistributor(dep.lossDistributor, dep.name)
+      const multicall = getMulticallReader(dep.multicallReader, dep.name)
 
       try {
-        const account = await cp.getUnderwriterAccount(addr)
+        const baseCalls = [
+          { target: dep.capitalPool, callData: cp.interface.encodeFunctionData('getUnderwriterAccount', [addr]) },
+          { target: dep.poolRegistry, callData: pr.interface.encodeFunctionData('getPoolCount') },
+          { target: dep.riskManager, callData: rm.interface.encodeFunctionData('underwriterTotalPledge', [addr]) },
+        ]
+        const baseResults = await multicall.tryAggregate(false, baseCalls)
+
+        const account = baseResults[0].success
+          ? cp.interface.decodeFunctionResult('getUnderwriterAccount', baseResults[0].returnData)
+          : [0n, 0n, 0n, 0n, 0n]
 
         let poolCount = 0n
-        try {
-          poolCount = await pr.getPoolCount()
-        } catch {
+        if (baseResults[1].success) {
+          try {
+            poolCount = pr.interface.decodeFunctionResult('getPoolCount', baseResults[1].returnData)[0]
+          } catch {}
+        }
+        if (!baseResults[1].success) {
           while (true) {
             try { await pr.getPoolData(poolCount); poolCount++ } catch { break }
           }
         }
 
-        const allocatedPoolIds: number[] = []
-        const pendingLosses: Record<string, string> = {}
-        for (let i = 0; i < Number(poolCount); i++) {
+        let pledge = 0n
+        if (baseResults[2].success) {
           try {
-            const allocated = await rm.isAllocatedToPool(addr, BigInt(i))
-            if (allocated) allocatedPoolIds.push(i)
-            if (allocated) {
-              const pledge = await rm.underwriterTotalPledge(addr)
-              const loss = await ld.getPendingLosses(addr, BigInt(i), pledge)
-              pendingLosses[i] = loss.toString()
-            }
+            pledge = rm.interface.decodeFunctionResult('underwriterTotalPledge', baseResults[2].returnData)[0]
+          } catch {}
+        }
+
+        const allocCalls: { target: string; callData: string }[] = []
+        for (let i = 0; i < Number(poolCount); i++) {
+          allocCalls.push({
+            target: dep.riskManager,
+            callData: rm.interface.encodeFunctionData('isAllocatedToPool', [addr, BigInt(i)]),
+          })
+        }
+
+        const allocResults = await multicall.tryAggregate(false, allocCalls)
+
+        const allocatedPoolIds: number[] = []
+        for (let i = 0; i < allocResults.length; i++) {
+          if (!allocResults[i].success) continue
+          try {
+            const [alloc] = rm.interface.decodeFunctionResult('isAllocatedToPool', allocResults[i].returnData)
+            if (alloc) allocatedPoolIds.push(i)
+          } catch {}
+        }
+
+        const lossCalls: { target: string; callData: string }[] = []
+        for (const id of allocatedPoolIds) {
+          lossCalls.push({
+            target: dep.lossDistributor,
+            callData: ld.interface.encodeFunctionData('getPendingLosses', [addr, BigInt(id), pledge]),
+          })
+        }
+
+        const lossResults = await multicall.tryAggregate(false, lossCalls)
+
+        const pendingLosses: Record<string, string> = {}
+        for (let i = 0; i < lossResults.length; i++) {
+          if (!lossResults[i].success) continue
+          try {
+            const [loss] = ld.interface.decodeFunctionResult('getPendingLosses', lossResults[i].returnData)
+            pendingLosses[allocatedPoolIds[i]] = loss.toString()
           } catch {}
         }
 


### PR DESCRIPTION
## Summary
- use MulticallReader to batch adapter reads
- batch calls in underwriter endpoint
- use multicall for cat pool user balances
- batch reserve config queries
- batch staking stats calls

## Testing
- `npm test` *(fails: Cannot find module 'vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_685191d5c73c832e861377a7f6c31e4c