### PR TITLE
Move edit allocation button

### DIFF
--- a/frontend/app/components/UnderwritingPositions.js
+++ b/frontend/app/components/UnderwritingPositions.js
@@ -307,14 +307,6 @@ const underwritingPositions = (details || [])
             </div>
           </div>
         </div>
-        <div className="mt-4 text-right">
-          <button
-            onClick={() => setShowAllocModal(true)}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
-          >
-            Edit Allocation
-          </button>
-        </div>
       </div>
 
       {activePositions.length > 0 && (
@@ -619,6 +611,12 @@ const underwritingPositions = (details || [])
         </div>
       )}
       <div className="mt-4 flex justify-end">
+        <button
+          onClick={() => setShowAllocModal(true)}
+          className="mr-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
+        >
+          Edit Allocation
+        </button>
         <button
           onClick={handleClaimAllRewards}
           disabled={isClaimingAll}


### PR DESCRIPTION
## Summary
- move the Edit Allocation button next to Claim All Rewards in the underwriting positions table

## Testing
- `npm test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_68528c74ad4c832ea5cc6665cfb031e5