### PR TITLE
Add fallback payout logic on adapter failure

### DIFF
--- a/contracts/adapters/AaveV3Adapter.sol
+++ b/contracts/adapters/AaveV3Adapter.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IYieldAdapter.sol";
 import "../interfaces/IPoolAddressesProvider.sol";
 import "../interfaces/IPool.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract AaveV3Adapter is IYieldAdapter, Ownable {
     using SafeERC20 for IERC20;
@@ -86,6 +87,15 @@ contract AaveV3Adapter is IYieldAdapter, Ownable {
         uint256 liquid = underlyingToken.balanceOf(address(this));
         uint256 aTokenBal = aToken.balanceOf(address(this));
         return liquid + aTokenBal;
+    }
+
+    function emergencyTransfer(address _to, uint256 _amount) external onlyCapitalPool returns (uint256) {
+        uint256 bal = aToken.balanceOf(address(this));
+        uint256 amt = Math.min(_amount, bal);
+        if (amt > 0) {
+            aToken.safeTransfer(_to, amt);
+        }
+        return amt;
     }
 
     // Get current APR for the underlying token

--- a/contracts/interfaces/IRiskManagerWithCat.sol
+++ b/contracts/interfaces/IRiskManagerWithCat.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "./ICatInsurancePool.sol";
+
+interface IRiskManagerWithCat {
+    function catPool() external view returns (ICatInsurancePool);
+}

--- a/contracts/interfaces/IYieldAdapterEmergency.sol
+++ b/contracts/interfaces/IYieldAdapterEmergency.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IYieldAdapterEmergency {
+    function emergencyTransfer(address recipient, uint256 amount) external returns (uint256);
+}


### PR DESCRIPTION
## Summary
- implement emergency transfer of yield tokens on Aave and Moonwell adapters
- add optional interfaces for emergency transfers and cat pool lookup
- update `CapitalPool.executePayout` to fallback to receipt tokens or CatInsurancePool funds when adapter withdrawals fail

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6852d1cc6c9c832e86ed00b3100c8d87