### PR TITLE
Make reserve params configurable

### DIFF
--- a/contracts/core/PolicyManager.sol
+++ b/contracts/core/PolicyManager.sol
@@ -26,7 +26,7 @@ contract PolicyManager is Ownable, ReentrancyGuard {
     /* ───────────────────────── Constants ───────────────────────── */
     uint256 public constant BPS = 10_000;
     uint256 public constant SECS_YEAR = 365 days;
-    uint256 public constant COVER_COOLDOWN_PERIOD = 5 days;
+    uint256 public coverCooldownPeriod = 5 days;
 
     /* ───────────────────────── State Variables ───────────────────────── */
     IPoolRegistry public poolRegistry;
@@ -56,6 +56,7 @@ contract PolicyManager is Ownable, ReentrancyGuard {
     event AddressesSet(address indexed registry, address indexed capital, address indexed rewards, address rm);
     event CatPremiumShareSet(uint256 newBps);
     event CatPoolSet(address indexed newCatPool);
+    event CoverCooldownPeriodSet(uint256 newPeriod);
 
     /* ───────────────────────── Constructor ───────────────────────── */
     constructor(address _policyNFT, address _initialOwner) Ownable(_initialOwner) {
@@ -78,6 +79,11 @@ contract PolicyManager is Ownable, ReentrancyGuard {
         require(_newBps <= 5000, "PM: Max share is 50%");
         catPremiumBps = _newBps;
         emit CatPremiumShareSet(_newBps);
+    }
+
+    function setCoverCooldownPeriod(uint256 _newPeriod) external onlyOwner {
+        coverCooldownPeriod = _newPeriod;
+        emit CoverCooldownPeriodSet(_newPeriod);
     }
 
     /* ───────────────────── Policy Management Functions ───────────────────── */
@@ -103,7 +109,7 @@ contract PolicyManager is Ownable, ReentrancyGuard {
 
         capitalPool.underlyingAsset().safeTransferFrom(msg.sender, address(this), _initialPremiumDeposit);
 
-        uint256 activationTimestamp = block.timestamp + COVER_COOLDOWN_PERIOD;
+        uint256 activationTimestamp = block.timestamp + coverCooldownPeriod;
         policyId = policyNFT.mint(
             msg.sender, _poolId, _coverageAmount, activationTimestamp,
             uint128(_initialPremiumDeposit), uint128(activationTimestamp)

--- a/frontend/abi/CapitalPool.json
+++ b/frontend/abi/CapitalPool.json
@@ -356,7 +356,7 @@
 	},
 	{
 		"inputs": [],
-		"name": "UNDERWRITER_NOTICE_PERIOD",
+                "name": "underwriterNoticePeriod",
 		"outputs": [
 			{
 				"internalType": "uint256",

--- a/frontend/abi/PoolManager.json
+++ b/frontend/abi/PoolManager.json
@@ -226,7 +226,7 @@
 	},
 	{
 		"inputs": [],
-		"name": "COVER_COOLDOWN_PERIOD",
+                "name": "coverCooldownPeriod",
 		"outputs": [
 			{
 				"internalType": "uint256",

--- a/frontend/abi/RiskManager.json
+++ b/frontend/abi/RiskManager.json
@@ -253,7 +253,7 @@
 	},
 	{
 		"inputs": [],
-		"name": "MAX_ALLOCATIONS_PER_UNDERWRITER",
+                "name": "maxAllocationsPerUnderwriter",
 		"outputs": [
 			{
 				"internalType": "uint256",

--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -18,21 +18,21 @@ export async function GET(req: Request) {
     const multicall = getMulticallReader(dep.multicallReader, dep.name)
 
     const calls = [
-      { target: dep.poolManager, callData: pm.interface.encodeFunctionData('COVER_COOLDOWN_PERIOD') },
+      { target: dep.poolManager, callData: pm.interface.encodeFunctionData('coverCooldownPeriod') },
       { target: dep.riskManager, callData: rm.interface.encodeFunctionData('CLAIM_FEE_BPS') },
-      { target: dep.capitalPool, callData: cp.interface.encodeFunctionData('UNDERWRITER_NOTICE_PERIOD') },
+      { target: dep.capitalPool, callData: cp.interface.encodeFunctionData('underwriterNoticePeriod') },
     ]
 
     const res = await multicall.tryAggregate(false, calls)
 
     const cooldown = res[0].success
-      ? pm.interface.decodeFunctionResult('COVER_COOLDOWN_PERIOD', res[0].returnData)[0]
+      ? pm.interface.decodeFunctionResult('coverCooldownPeriod', res[0].returnData)[0]
       : 0n
     const claimFee = res[1].success
       ? rm.interface.decodeFunctionResult('CLAIM_FEE_BPS', res[1].returnData)[0]
       : 0n
     const notice = res[2].success
-      ? cp.interface.decodeFunctionResult('UNDERWRITER_NOTICE_PERIOD', res[2].returnData)[0]
+      ? cp.interface.decodeFunctionResult('underwriterNoticePeriod', res[2].returnData)[0]
       : 0n
     return NextResponse.json({
       coverCooldownPeriod: cooldown.toString(),

--- a/frontend/hooks/useReserveConfig.js
+++ b/frontend/hooks/useReserveConfig.js
@@ -17,9 +17,9 @@ export default function useReserveConfig(deployment) {
         const cp = getCapitalPool(dep.capitalPool, dep.name)
         const pm = getPoolManager(dep.poolManager, dep.name)
         const [cooldown, claimFee, notice] = await Promise.all([
-          pm.COVER_COOLDOWN_PERIOD(),
+          pm.coverCooldownPeriod(),
           rm.CLAIM_FEE_BPS(),
-          cp.UNDERWRITER_NOTICE_PERIOD(),
+          cp.underwriterNoticePeriod(),
         ])
         setConfig({
           coverCooldownPeriod: Number(cooldown.toString()),

--- a/subgraphs/insurance/abis/CapitalPool.json
+++ b/subgraphs/insurance/abis/CapitalPool.json
@@ -324,7 +324,7 @@
   },
   {
     "inputs": [],
-    "name": "UNDERWRITER_NOTICE_PERIOD",
+  "name": "underwriterNoticePeriod",
     "outputs": [
       {
         "internalType": "uint256",

--- a/subgraphs/insurance/abis/RiskManager.json
+++ b/subgraphs/insurance/abis/RiskManager.json
@@ -428,7 +428,7 @@
   },
   {
     "inputs": [],
-    "name": "COVER_COOLDOWN_PERIOD",
+  "name": "coverCooldownPeriod",
     "outputs": [
       {
         "internalType": "uint256",
@@ -441,7 +441,7 @@
   },
   {
     "inputs": [],
-    "name": "MAX_ALLOCATIONS_PER_UNDERWRITER",
+  "name": "maxAllocationsPerUnderwriter",
     "outputs": [
       {
         "internalType": "uint256",

--- a/test/CapitalPool.test.js
+++ b/test/CapitalPool.test.js
@@ -43,16 +43,8 @@ describe("CapitalPool", function () {
 
         // --- Deploy CapitalPool ---
         CapitalPoolFactory = await ethers.getContractFactory("CapitalPool");
-
-        // We override the contract's constant for testing purposes by deploying a modified version
-        const originalBytecode = CapitalPoolFactory.bytecode;
-        const noticePeriodHex = ethers.toBeHex(NOTICE_PERIOD, 32);
-        const modifiedBytecode = originalBytecode.replace(
-            "0000000000000000000000000000000000000000000000000000000000000000", // Placeholder for 0 days
-            noticePeriodHex.slice(2)
-        );
-        const CapitalPoolModifiedFactory = new ethers.ContractFactory(CapitalPoolFactory.interface, modifiedBytecode, owner);
-        capitalPool = await CapitalPoolModifiedFactory.deploy(owner.address, mockUsdc.target);
+        capitalPool = await CapitalPoolFactory.deploy(owner.address, mockUsdc.target);
+        await capitalPool.setUnderwriterNoticePeriod(NOTICE_PERIOD);
 
         // --- Initial Setup ---
         await mockUsdc.transfer(user1.address, ethers.parseUnits("10000", 6));


### PR DESCRIPTION
## Summary
- allow changing risk manager allocations limit
- make underwriter withdrawal notice period adjustable
- make cover purchase cooldown configurable
- update tests, frontend and subgraphs for new names

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6852d6592350832e9c9065bba0513c6c