### PR TITLE
Display underlying tokens for underwriters

### DIFF
--- a/frontend/app/api/pools/list/route.ts
+++ b/frontend/app/api/pools/list/route.ts
@@ -139,9 +139,14 @@ export async function GET() {
       const multicall = getMulticallReader(dep.multicallReader, dep.name);
       const pools: any[] = [];
       let underlyingDec = 6;
+      let underlyingAsset = "";
       try {
+        underlyingAsset = await getUnderlyingAssetAddress(
+          dep.capitalPool,
+          dep.name,
+        );
         underlyingDec = Number(
-          await getUnderlyingAssetDecimals(dep.capitalPool, dep.name)
+          await getUnderlyingAssetDecimals(dep.capitalPool, dep.name),
         );
       } catch {
         // ignore
@@ -253,6 +258,7 @@ export async function GET() {
         allPools.push({
           deployment: dep.name,
           underlyingAssetDecimals: underlyingDec,
+          underlyingAsset,
           ...p,
         });
       }

--- a/frontend/app/components/UnderwriterPanel.js
+++ b/frontend/app/components/UnderwriterPanel.js
@@ -36,10 +36,17 @@ const protocolCategories = [
 export default function UnderwriterPanel({ displayCurrency }) {
   const { isConnected } = useAccount()
   const { pools, loading } = usePools()
-  const tokens = useTokenList(pools)
+  const tokens = useTokenList(
+    pools.map((p) => ({
+      protocolTokenToCover: p.underlyingAsset || p.protocolTokenToCover,
+    })),
+  )
   const [selectedToken, setSelectedToken] = useState(null)
   const tokenDeploymentMap = Object.fromEntries(
-    pools.map((p) => [p.protocolTokenToCover.toLowerCase(), p.deployment]),
+    pools.map((p) => [
+      (p.underlyingAsset || p.protocolTokenToCover).toLowerCase(),
+      p.deployment,
+    ]),
   )
   const selectedDeployment =
     selectedToken && tokenDeploymentMap[selectedToken.address.toLowerCase()]
@@ -87,7 +94,8 @@ export default function UnderwriterPanel({ displayCurrency }) {
         }
       }
       acc[id].pools.push({
-        token: pool.protocolTokenToCover,
+        token: pool.underlyingAsset,
+        coveredToken: pool.protocolTokenToCover,
         premium: Number(pool.premiumRateBps || 0) / 100,
         underwriterYield: Number(pool.underwriterYieldBps || 0) / 100,
         tvl: Number(


### PR DESCRIPTION
## Summary
- surface underlying asset address in pool API
- derive token list from pool underlying assets
- reference underlying asset when mapping deployments
- track underlying asset for each pool entry

## Testing
- `npx hardhat test` *(fails: couldn't download compiler due to network restrictions)*
- `npm run lint` in `frontend` *(fails: Next.js not installed due to dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6853c22f5b4c832ea5565e62105e8f55