### PR TITLE
Rename site to LayerCover

### DIFF
--- a/frontend/app/components/MobileNav.js
+++ b/frontend/app/components/MobileNav.js
@@ -50,7 +50,10 @@ export default function MobileNav() {
         <div className="fixed inset-0 z-50 bg-gray-900/50 backdrop-blur-sm">
           <div className="fixed inset-y-0 right-0 w-full max-w-xs bg-white dark:bg-gray-800 shadow-xl flex flex-col">
             <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
-              <h2 className="text-xl font-bold text-blue-600 dark:text-blue-400">DeFi Shield</h2>
+              <h2 className="flex items-center text-xl font-bold text-blue-600 dark:text-blue-400">
+                <img src="/layercover-logo.svg" alt="LayerCover logo" className="h-8 w-8 mr-2" />
+                LayerCover
+              </h2>
               <button
                 onClick={() => setIsOpen(false)}
                 className="p-2 rounded-md text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
@@ -87,7 +90,7 @@ export default function MobileNav() {
             </nav>
 
             <div className="p-4 border-t border-gray-200 dark:border-gray-700">
-              <div className="text-sm text-gray-500 dark:text-gray-400 text-center">© 2024 DeFi Shield</div>
+              <div className="text-sm text-gray-500 dark:text-gray-400 text-center">© 2024 LayerCover</div>
             </div>
           </div>
         </div>

--- a/frontend/app/components/Navbar.js
+++ b/frontend/app/components/Navbar.js
@@ -36,8 +36,9 @@ export default function Navbar() {
         <div className="flex h-16 justify-between">
           <div className="flex">
             <div className="flex flex-shrink-0 items-center">
-              <Link href="/" className="text-xl font-bold text-blue-600 dark:text-blue-400">
-                DeFi Shield
+              <Link href="/" className="flex items-center text-xl font-bold text-blue-600 dark:text-blue-400">
+                <img src="/layercover-logo.svg" alt="LayerCover logo" className="h-8 w-8 mr-2" />
+                <span>LayerCover</span>
               </Link>
             </div>
             <div className="hidden sm:ml-6 sm:flex sm:space-x-8">

--- a/frontend/app/config.js
+++ b/frontend/app/config.js
@@ -44,7 +44,7 @@ const baseMainnet = {
 
 // 4. Use getDefaultConfig to create wagmi/RainbowKit config
 export const config = getDefaultConfig({
-  appName: 'DeFi Insurance Platform',
+  appName: 'LayerCover',
   projectId: projectId || 'DEFAULT_PROJECT_ID_IF_MISSING',
   chains: [baseMainnet],
   transports: {

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -9,7 +9,7 @@ import Sidebar from "./components/Sidebar"; // Ensure paths are correct
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
-  title: "DeFi Insurance Platform",
+  title: "LayerCover",
   description: "Insurance coverage for DeFi protocols",
 };
 

--- a/frontend/public/layercover-logo.svg
+++ b/frontend/public/layercover-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24">
+  <rect width="120" height="24" fill="#1e40af" />
+  <text x="60" y="16" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="white" text-anchor="middle">LayerCover</text>
+</svg>


### PR DESCRIPTION
## Summary
- rename the DeFi Insurance Platform site as LayerCover
- show new LayerCover logo in Navbar and mobile nav
- add `layercover-logo.svg`

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6853c2bc7f4c832e80ca3c69ed12f6bb