### PR TITLE
Move claims section to page bottom

### DIFF
--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -111,11 +111,6 @@ export default function Dashboard() {
         {showPositionsFirst ? underwritingPositionsSection : activeCoveragesSection}
         {showPositionsFirst ? activeCoveragesSection : underwritingPositionsSection}
 
-        {/* Add Claims Section */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-          <h2 className="text-xl font-semibold mb-4">Claims & Affected Positions</h2>
-          <ClaimsSection displayCurrency={displayCurrency} />
-        </div>
 
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6 space-y-4">
           <div className="flex items-center justify-between mb-4">
@@ -220,6 +215,12 @@ export default function Dashboard() {
             </div>
           </div>
         )}
+
+        {/* Claims & Affected Positions moved to bottom */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-xl font-semibold mb-4">Claims & Affected Positions</h2>
+          <ClaimsSection displayCurrency={displayCurrency} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- move Claims & Affected Positions section to the bottom of the dashboard page

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `frontend` *(fails to run vitest due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853df3109dc832eb71982ba69b2ecef