### PR TITLE
Connect gov rewards claim button

### DIFF
--- a/frontend/app/api/committee/claim/route.ts
+++ b/frontend/app/api/committee/claim/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { getCommitteeWriter } from '../../../../lib/committee'
+import deployments from '../../../config/deployments'
+
+export async function POST(req: Request) {
+  try {
+    const { proposalIds, deployment: depName } = await req.json()
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
+    const committee = getCommitteeWriter(dep.committee, dep.name)
+    for (const id of proposalIds as number[]) {
+      const tx = await committee.claimReward(id)
+      await tx.wait()
+    }
+    return NextResponse.json({ ok: true })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}

--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -57,14 +57,15 @@ export default function Dashboard() {
     if (!pastProposals || pastProposals.length === 0) return
     setIsClaimingRewards(true)
     try {
-      const committee = await getCommitteeWithSigner()
-      for (const p of pastProposals) {
-        try {
-          const tx = await committee.claimReward(p.id)
-          await tx.wait()
-        } catch (err) {
-          console.error(`Failed to claim reward for proposal ${p.id}`, err)
-        }
+      const ids = pastProposals.map((p) => p.id)
+      const res = await fetch('/api/committee/claim', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proposalIds: ids })
+      })
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || 'Failed to claim')
       }
     } catch (err) {
       console.error('Failed to claim rewards', err)

--- a/frontend/app/staking/page.js
+++ b/frontend/app/staking/page.js
@@ -28,14 +28,15 @@ export default function StakingPage() {
     if (pastProposals.length === 0) return
     setIsClaimingRewards(true)
     try {
-      const committee = await getCommitteeWithSigner()
-      for (const p of pastProposals) {
-        try {
-          const tx = await committee.claimReward(p.id)
-          await tx.wait()
-        } catch (err) {
-          console.error(`Failed to claim reward for proposal ${p.id}`, err)
-        }
+      const ids = pastProposals.map((p) => p.id)
+      const res = await fetch('/api/committee/claim', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proposalIds: ids })
+      })
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || 'Failed to claim')
       }
     } catch (err) {
       console.error('Failed to claim rewards', err)

--- a/frontend/lib/committee.ts
+++ b/frontend/lib/committee.ts
@@ -27,3 +27,10 @@ export async function getCommitteeWithSigner() {
 
   return new ethers.Contract(ADDRESS, Committee, signer)
 }
+
+export function getCommitteeWriter(address: string = ADDRESS, deployment?: string) {
+  const pk = process.env.PRIVATE_KEY
+  if (!pk) throw new Error('PRIVATE_KEY not set')
+  const signer = new ethers.Wallet(pk, getProvider(deployment))
+  return new ethers.Contract(address, Committee, signer)
+}


### PR DESCRIPTION
## Summary
- add committee writer contract helper
- implement API route for claiming governance rewards
- wire dashboard and staking claim buttons to new API

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: Cannot find module 'vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_6853e03bae04832eb3efda59a88fe734