### PR TITLE
Use shared contract addresses from deployment config

### DIFF
--- a/frontend/app/components/BondModal.js
+++ b/frontend/app/components/BondModal.js
@@ -18,6 +18,7 @@ import {
   getProtocolName,
   getProtocolLogo,
 } from "../config/tokenNameMap"
+import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
 import {
   getERC20WithSigner,
   getTokenDecimals,
@@ -43,7 +44,7 @@ export default function BondModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [maxPayout, setMaxPayout] = useState("0")
-  const tokenAddress = process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS
+  const tokenAddress = STAKING_TOKEN_ADDRESS
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
   const [balance, setBalance] = useState("0")

--- a/frontend/app/components/StakeModal.js
+++ b/frontend/app/components/StakeModal.js
@@ -8,6 +8,7 @@ import { getStakingWithSigner } from "../../lib/staking"
 import { getERC20WithSigner, getTokenDecimals, getTokenSymbol } from "../../lib/erc20"
 import { getTokenLogo } from "../config/tokenNameMap"
 import Modal from "./Modal"
+import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
 
 export default function StakeModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
@@ -15,7 +16,7 @@ export default function StakeModal({ isOpen, onClose }) {
   const [balance, setBalance] = useState("0")
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
-  const tokenAddress = process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS
+  const tokenAddress = STAKING_TOKEN_ADDRESS
 
   const loadBalance = async () => {
     if (!tokenAddress) return

--- a/frontend/app/components/UnstakeModal.js
+++ b/frontend/app/components/UnstakeModal.js
@@ -8,6 +8,7 @@ import { getStakingWithSigner } from "../../lib/staking"
 import { getERC20WithSigner, getTokenDecimals, getTokenSymbol } from "../../lib/erc20"
 import { getTokenLogo } from "../config/tokenNameMap"
 import Modal from "./Modal"
+import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
 
 export default function UnstakeModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
@@ -15,7 +16,7 @@ export default function UnstakeModal({ isOpen, onClose }) {
   const [balance, setBalance] = useState("0")
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
-  const tokenAddress = process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS
+  const tokenAddress = STAKING_TOKEN_ADDRESS
 
   const loadBalance = async () => {
     if (!tokenAddress) return

--- a/frontend/app/config/deployments.js
+++ b/frontend/app/config/deployments.js
@@ -70,3 +70,19 @@ export default deployments;
 export function getDeployment(name) {
   return deployments.find((d) => d.name === name) || deployments[0];
 }
+
+export const STAKING_TOKEN_ADDRESS =
+  (deployments[0] && deployments[0].governanceToken) ||
+  process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS;
+
+export const COMMITTEE_ADDRESS =
+  (deployments[0] && deployments[0].committee) ||
+  process.env.NEXT_PUBLIC_COMMITTEE_ADDRESS;
+
+export const PRICE_ORACLE_ADDRESS =
+  (deployments[0] && deployments[0].priceOracle) ||
+  process.env.NEXT_PUBLIC_PRICE_ORACLE_ADDRESS;
+
+export const MULTICALL_READER_ADDRESS =
+  (deployments[0] && deployments[0].multicallReader) ||
+  process.env.NEXT_PUBLIC_MULTICALL_READER_ADDRESS;

--- a/frontend/app/config/tokenNameMap.js
+++ b/frontend/app/config/tokenNameMap.js
@@ -1,4 +1,5 @@
 import { IdCard } from "lucide-react";
+import { STAKING_TOKEN_ADDRESS } from "./deployments";
 
 export const PROTOCOL_NAME_MAP = {
   0: 'Aave V3',
@@ -71,9 +72,9 @@ export const TOKEN_LOGO_MAP = {
   "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376": '/images/stablecoins/dai.svg'
 };
 
-if (process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS) {
-  TOKEN_NAME_MAP[process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS] = 'Staking Token';
-  TOKEN_LOGO_MAP[process.env.NEXT_PUBLIC_STAKING_TOKEN_ADDRESS] = '/images/tokens/placeholder-token.svg';
+if (STAKING_TOKEN_ADDRESS) {
+  TOKEN_NAME_MAP[STAKING_TOKEN_ADDRESS] = 'Staking Token';
+  TOKEN_LOGO_MAP[STAKING_TOKEN_ADDRESS] = '/images/tokens/placeholder-token.svg';
 }
 
 export function getProtocolType(id) {

--- a/frontend/lib/committee.ts
+++ b/frontend/lib/committee.ts
@@ -1,11 +1,9 @@
 import { ethers } from 'ethers'
 import Committee from '../abi/Committee.json'
 import { getProvider, provider } from './provider'
-import deployments from '../app/config/deployments'
+import deployments, { COMMITTEE_ADDRESS } from '../app/config/deployments'
 
-const ADDRESS =
-  (deployments[0] && deployments[0].committee) ||
-  (process.env.NEXT_PUBLIC_COMMITTEE_ADDRESS as string)
+const ADDRESS = COMMITTEE_ADDRESS as string
 
 if (!ADDRESS) {
   console.error('❌  Committee address not configured')

--- a/frontend/lib/multicallReader.ts
+++ b/frontend/lib/multicallReader.ts
@@ -1,11 +1,9 @@
 import { ethers } from 'ethers'
 import MulticallReader from '../abi/MulticallReader.json'
 import { getProvider, provider } from './provider'
-import deployments from '../app/config/deployments'
+import deployments, { MULTICALL_READER_ADDRESS } from '../app/config/deployments'
 
-const DEFAULT_ADDRESS =
-  (deployments[0] && deployments[0].multicallReader) ||
-  (process.env.NEXT_PUBLIC_MULTICALL_READER_ADDRESS as string)
+const DEFAULT_ADDRESS = MULTICALL_READER_ADDRESS as string
 
 export function getMulticallReader(address: string = DEFAULT_ADDRESS, deployment?: string) {
   return new ethers.Contract(address, MulticallReader, getProvider(deployment))

--- a/frontend/lib/priceOracle.ts
+++ b/frontend/lib/priceOracle.ts
@@ -1,11 +1,9 @@
 import { ethers } from 'ethers'
 import PriceOracle from '../abi/PriceOracle.json'
 import { getProvider, provider } from './provider'
-import deployments from '../app/config/deployments'
+import deployments, { PRICE_ORACLE_ADDRESS } from '../app/config/deployments'
 
-const DEFAULT_ADDRESS =
-  (deployments[0] && deployments[0].priceOracle) ||
-  (process.env.NEXT_PUBLIC_PRICE_ORACLE_ADDRESS as string);
+const DEFAULT_ADDRESS = PRICE_ORACLE_ADDRESS as string;
 
 export function getPriceOracle(address: string = DEFAULT_ADDRESS, deployment?: string) {
   return new ethers.Contract(address, PriceOracle, getProvider(deployment));


### PR DESCRIPTION
## Summary
- centralize shared addresses in `deployments.js`
- reference `STAKING_TOKEN_ADDRESS` in modals and token map
- use constants in committee, priceOracle and multicallReader libs

## Testing
- `npm run test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6853e6012694832eb0aad4f335067825