### PR TITLE
Fix stablecoin filter in underwriting panel

### DIFF
--- a/frontend/app/components/UnderwriterPanel.js
+++ b/frontend/app/components/UnderwriterPanel.js
@@ -13,7 +13,8 @@ import {
   UNDERLYING_TOKEN_MAP,
   getTokenName,
   getUnderlyingTokenName,
-  getUnderlyingTokenLogo
+  getUnderlyingTokenLogo,
+  getProtocolType
 } from "../config/tokenNameMap"
 import useYieldAdapters from "../../hooks/useYieldAdapters"
 import { YieldPlatform, getYieldPlatformInfo } from "../config/yieldPlatforms"
@@ -105,7 +106,10 @@ export default function UnderwriterPanel({ displayCurrency }) {
           id,
           name: getProtocolName(pool.id),
           description: `${getProtocolDescription(pool.id)}`,
-          category: "lending",
+          // Categorise protocol type so the filter works correctly
+          // Stablecoin pools should be marked as such; everything else defaults
+          // to lending for now.
+          category: getProtocolType(pool.id) === 'stablecoin' ? 'stablecoin' : 'lending',
           pools: [],
         }
       }


### PR DESCRIPTION
## Summary
- mark stablecoin protocols when building market data so the 'Stablecoin' filter works

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in `frontend` (fails: cannot find module 'vitest.mjs')

------
https://chatgpt.com/codex/tasks/task_e_6853f6ddabf0832ea0c20c58a29ab39a