### PR TITLE
Add pending rewards dropdown for underwriting

### DIFF
--- a/frontend/app/api/underwriters/[address]/rewards/[poolId]/route.ts
+++ b/frontend/app/api/underwriters/[address]/rewards/[poolId]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { getRewardDistributor } from '@/lib/rewardDistributor'
+import { getRiskManager } from '@/lib/riskManager'
+import { getPoolRegistry } from '@/lib/poolRegistry'
+import deployments from '../../../../../config/deployments'
+
+export async function GET(_req: Request, { params }: { params: { address: string; poolId: string } }) {
+  try {
+    const addr = params.address.toLowerCase()
+    const id = BigInt(params.poolId)
+    const results: any[] = []
+    for (const dep of deployments) {
+      const rd = getRewardDistributor(dep.rewardDistributor, dep.name)
+      const rm = getRiskManager(dep.riskManager, dep.name)
+      const pr = getPoolRegistry(dep.poolRegistry, dep.name)
+      try {
+        const pool = await pr.getPoolData(id)
+        const pledge = await rm.underwriterTotalPledge(addr)
+        const pending = await rd.pendingRewards(addr, id, pool.protocolTokenToCover, pledge)
+        results.push({ deployment: dep.name, rewardToken: pool.protocolTokenToCover, pending: pending.toString() })
+      } catch {}
+    }
+    return NextResponse.json({ address: addr, poolId: Number(params.poolId), rewards: results })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}

--- a/frontend/hooks/usePendingRewards.js
+++ b/frontend/hooks/usePendingRewards.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react'
+
+export default function usePendingRewards(address, poolId, deployment) {
+  const [amount, setAmount] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!address || poolId == null || !deployment) return
+    async function load() {
+      try {
+        const res = await fetch(`/api/underwriters/${address}/rewards/${poolId}?deployment=${deployment}`)
+        if (res.ok) {
+          const data = await res.json()
+          const item = (data.rewards || []).find(r => r.deployment === deployment)
+          setAmount(item ? item.pending : '0')
+        }
+      } catch (err) {
+        console.error('Failed to load pending rewards', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [address, poolId, deployment])
+
+  return { amount, loading }
+}


### PR DESCRIPTION
## Summary
- fetch pending rewards for an underwriter per pool via new API route
- expose a React hook for pending reward data
- show pending rewards, manage link, claim button and pool link in Underwriting Positions dropdown

## Testing
- `npm test` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6853f65da82c832e8eb5aa4065ae296f