### PR TITLE
Update provide coverage links

### DIFF
--- a/frontend/app/markets/page.js
+++ b/frontend/app/markets/page.js
@@ -1,18 +1,27 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useAccount } from "wagmi"
 import MarketsTable from "../components/MarketsTable"
 import UnderwriterPanel from "../components/UnderwriterPanel"
 import CurrencyToggle from "../components/CurrencyToggle"
 // import ConnectWallet from "../components/ConnectWallet"
 import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { useSearchParams } from "next/navigation"
 
 
 export default function Markets() {
   const { isConnected } = useAccount()
+  const searchParams = useSearchParams()
   const [displayCurrency, setDisplayCurrency] = useState("native") // 'native' or 'usd'
   const [activeTab, setActiveTab] = useState("purchase") // 'purchase' or 'underwrite'
+
+  useEffect(() => {
+    const tab = searchParams.get("tab")
+    if (tab === "underwrite") {
+      setActiveTab("underwrite")
+    }
+  }, [searchParams])
 
   return (
     <div className="container mx-auto max-w-7xl">

--- a/frontend/app/pool/[protocol]/[token]/page.js
+++ b/frontend/app/pool/[protocol]/[token]/page.js
@@ -84,7 +84,6 @@ export default function PoolDetailsPage() {
     utilHistory,
   } = usePoolHistory(poolId)
   const [purchaseModalOpen, setPurchaseModalOpen] = useState(false)
-  const [provideModalOpen, setProvideModalOpen] = useState(false)
 
   const premiumCanvasRef = useRef(null)
   const utilCanvasRef = useRef(null)
@@ -529,10 +528,9 @@ export default function PoolDetailsPage() {
       </div>
       <div className="flex flex-col sm:flex-row gap-3 md:gap-4 mb-8">
         <button className="flex-1 py-2.5 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-colors duration-150 ease-in-out text-sm sm:text-base flex items-center justify-center shadow-sm hover:shadow" onClick={()=>setPurchaseModalOpen(true)}>Purchase Coverage</button>
-        <button className="flex-1 py-2.5 px-4 bg-green-600 hover:bg-green-700 text-white font-medium rounded-md transition-colors duration-150 ease-in-out text-sm sm:text-base flex items-center justify-center shadow-sm hover:shadow" onClick={()=>setProvideModalOpen(true)}>Provide Coverage</button>
+        <Link href="/markets?tab=underwrite" className="flex-1 py-2.5 px-4 bg-green-600 hover:bg-green-700 text-white font-medium rounded-md transition-colors duration-150 ease-in-out text-sm sm:text-base flex items-center justify-center shadow-sm hover:shadow">Provide Coverage</Link>
       </div>
       <CoverageModal isOpen={purchaseModalOpen} onClose={()=>setPurchaseModalOpen(false)} type="purchase" protocol={market.name} token={token} premium={processedPool?.premium} yield={processedPool?.underwriterYield} deployment={pool?.deployment}/>
-      <CoverageModal isOpen={provideModalOpen} onClose={()=>setProvideModalOpen(false)} type="provide" protocol={market.name} token={token} premium={processedPool?.premium} yield={processedPool?.underwriterYield} deployment={pool?.deployment}/>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- link Provide Coverage button on pool details to Insurance Markets page
- read `tab` search param on Markets page to open the Provide Coverage tab by default

## Testing
- `npm test --prefix frontend` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6853fd864dc4832ebc9e3e668da5cf8c