### PR TITLE
Show tx link inside modals

### DIFF
--- a/frontend/app/components/BondModal.js
+++ b/frontend/app/components/BondModal.js
@@ -13,7 +13,7 @@ import usePools from "../../hooks/usePools"
 // the Insurance Markets page so only unique underlying assets show up in the
 // dropdown.
 import { getUnderlyingTokenLogo, getUnderlyingTokenName } from "../config/tokenNameMap"
-import { notifyTx } from "../utils/explorer"
+import { getTxExplorerUrl } from "../utils/explorer"
 import useClaims from "../../hooks/useClaims"
 import {
   getProtocolName,
@@ -44,6 +44,7 @@ export default function BondModal({ isOpen, onClose }) {
   const [selectedProtocol, setSelectedProtocol] = useState("")
   const [amount, setAmount] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [txHash, setTxHash] = useState("")
   const [maxPayout, setMaxPayout] = useState("0")
   const tokenAddress = STAKING_TOKEN_ADDRESS
   const [symbol, setSymbol] = useState("")
@@ -161,7 +162,7 @@ export default function BondModal({ isOpen, onClose }) {
         await approveTx.wait()
       }
       const tx = await staking.depositBond(pool.id, selectedAsset, value)
-      notifyTx(tx.hash)
+      setTxHash(tx.hash)
       await tx.wait()
       setAmount("")
       onClose()
@@ -331,6 +332,19 @@ export default function BondModal({ isOpen, onClose }) {
             "Deposit Bond"
           )}
         </button>
+        {txHash && (
+          <p className="text-xs text-center mt-2">
+            Transaction submitted.{' '}
+            <a
+              href={getTxExplorerUrl(txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              View on block explorer
+            </a>
+          </p>
+        )}
       </div>
     </Modal>
   )

--- a/frontend/app/components/CancelCoverageModal.js
+++ b/frontend/app/components/CancelCoverageModal.js
@@ -10,10 +10,11 @@ import {
   getTokenName,
 } from "../config/tokenNameMap";
 import { getPoolManagerWithSigner } from "../../lib/poolManager";
-import { notifyTx } from "../utils/explorer";
+import { getTxExplorerUrl } from "../utils/explorer";
 
 export default function CancelCoverageModal({ isOpen, onClose, coverage }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [txHash, setTxHash] = useState("");
 
   if (!coverage) return null;
 
@@ -27,7 +28,7 @@ export default function CancelCoverageModal({ isOpen, onClose, coverage }) {
       const dep = getDeployment(coverage.deployment);
       const pm = await getPoolManagerWithSigner(dep.poolManager);
       const tx = await pm.cancelCover(coverage.id, { gasLimit: 500000 });
-      notifyTx(tx.hash);
+      setTxHash(tx.hash);
       await tx.wait();
       onClose(true);
     } catch (err) {
@@ -78,6 +79,19 @@ export default function CancelCoverageModal({ isOpen, onClose, coverage }) {
           >
             {isSubmitting ? "Cancelling..." : "Confirm"}
           </button>
+          {txHash && (
+            <p className="text-xs text-center mt-2 w-full">
+              Transaction submitted.{' '}
+              <a
+                href={getTxExplorerUrl(txHash)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                View on block explorer
+              </a>
+            </p>
+          )}
         </div>
       </div>
     </Modal>

--- a/frontend/app/components/CatPoolModal.js
+++ b/frontend/app/components/CatPoolModal.js
@@ -7,7 +7,7 @@ import Modal from "./Modal"
 import { getCatPoolWithSigner, getUsdcAddress, getUsdcDecimals, getCatShareAddress } from "../../lib/catPool"
 import { getERC20WithSigner, getTokenDecimals } from "../../lib/erc20"
 import { getTokenLogo } from "../config/tokenNameMap"
-import { notifyTx } from "../utils/explorer"
+import { getTxExplorerUrl } from "../utils/explorer"
 
 export default function CatPoolModal({
   isOpen,
@@ -23,6 +23,7 @@ export default function CatPoolModal({
   const [amount, setAmount] = useState("")
   const [usdValue, setUsdValue] = useState("0")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [txHash, setTxHash] = useState("")
   const [balance, setBalance] = useState("0")
   const projected = amount ? (Number.parseFloat(amount) * (apr / 100)).toFixed(2) : "0"
 
@@ -101,7 +102,7 @@ export default function CatPoolModal({
           await approveTx.wait()
         }
         const tx = await cp.depositLiquidity(amountBn)
-        notifyTx(tx.hash)
+        setTxHash(tx.hash)
         await tx.wait()
       } else {
         const dec = await getUsdcDecimals()
@@ -116,7 +117,7 @@ export default function CatPoolModal({
           ? ethers.BigNumber.from(0)
           : amountBn.mul(totalSupply).div(liquid)
         const tx = await cp.withdrawLiquidity(sharesBn)
-        notifyTx(tx.hash)
+        setTxHash(tx.hash)
         await tx.wait()
       }
       setAmount("")
@@ -259,6 +260,19 @@ export default function CatPoolModal({
             `${isDeposit ? "Deposit" : "Withdraw"} ${symbol}`
           )}
         </button>
+        {txHash && (
+          <p className="text-xs text-center mt-2">
+            Transaction submitted.{' '}
+            <a
+              href={getTxExplorerUrl(txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              View on block explorer
+            </a>
+          </p>
+        )}
       </div>
     </Modal>
   )

--- a/frontend/app/components/CoverageModal.js
+++ b/frontend/app/components/CoverageModal.js
@@ -18,7 +18,7 @@ import useUsdPrice from "../../hooks/useUsdPrice"
 import Modal from "./Modal"
 import { Slider } from "../../components/ui/slider"
 import { formatPercentage } from "../utils/formatting"
-import { notifyTx } from "../utils/explorer"
+import { getTxExplorerUrl } from "../utils/explorer"
 
 export default function CoverageModal({
   isOpen,
@@ -45,6 +45,7 @@ export default function CoverageModal({
   const [walletBalance, setWalletBalance] = useState(0)
   const [underlyingDec, setUnderlyingDec] = useState(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [txHash, setTxHash] = useState("")
   const [error, setError] = useState("")
 
   // Fetch underlying asset decimals whenever the modal opens
@@ -184,7 +185,7 @@ export default function CoverageModal({
         }
 
         const tx = await pm.purchaseCover(poolId, amountBn, depositBn)
-        notifyTx(tx.hash)
+        setTxHash(tx.hash)
         await tx.wait()
       } else {
         // "provide" flow
@@ -202,12 +203,12 @@ export default function CoverageModal({
         }
 
         const tx = await cp.deposit(amountBn, yieldChoice)
-        notifyTx(tx.hash)
+        setTxHash(tx.hash)
         await tx.wait()
 
         if (ids.length) {
           const tx2 = await rm.allocateCapital(ids)
-          notifyTx(tx2.hash)
+          setTxHash(tx2.hash)
           await tx2.wait()
         }
       }
@@ -405,6 +406,19 @@ export default function CoverageModal({
         >
           {isSubmitting ? "Submitting..." : "Confirm Transaction"}
         </button>
+        {txHash && (
+          <p className="text-xs text-center mt-2">
+            Transaction submitted.{' '}
+            <a
+              href={getTxExplorerUrl(txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              View on block explorer
+            </a>
+          </p>
+        )}
       </div>
     </Modal>
   )

--- a/frontend/app/components/ManageAllocationModal.js
+++ b/frontend/app/components/ManageAllocationModal.js
@@ -11,7 +11,7 @@ import { formatPercentage } from "../utils/formatting";
 import { getRiskManagerWithSigner } from "../../lib/riskManager";
 import deployments, { getDeployment } from "../config/deployments";
 import { YieldPlatform } from "../config/yieldPlatforms";
-import { notifyTx } from "../utils/explorer";
+import { getTxExplorerUrl } from "../utils/explorer";
 
 export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
   const { pools } = usePools();
@@ -39,6 +39,7 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
   const [selectedPools, setSelectedPools] = useState([]);
   const [initialPools, setInitialPools] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [txHash, setTxHash] = useState("");
 
   useEffect(() => {
     if (details) {
@@ -75,13 +76,13 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
 
       if (toAllocate.length > 0) {
         const tx = await rm.allocateCapital(toAllocate);
-        notifyTx(tx.hash);
+        setTxHash(tx.hash);
         await tx.wait();
       }
 
       if (toDeallocate.length > 0) {
         const tx2 = await rm.deallocateCapital(toDeallocate);
-        notifyTx(tx2.hash);
+        setTxHash(tx2.hash);
         await tx2.wait();
       }
 
@@ -163,6 +164,19 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
         >
           {isSubmitting ? "Submitting..." : "Save"}
         </button>
+        {txHash && (
+          <p className="text-xs text-center mt-2 ml-4">
+            Transaction submitted.{' '}
+            <a
+              href={getTxExplorerUrl(txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              View on block explorer
+            </a>
+          </p>
+        )}
       </div>
     </Modal>
   );

--- a/frontend/app/components/ProposalsTable.js
+++ b/frontend/app/components/ProposalsTable.js
@@ -7,7 +7,6 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 import { getCommitteeWithSigner } from '../../lib/committee'
 import { getStakingWithSigner } from '../../lib/staking'
 import { useAccount } from 'wagmi'
-import { notifyTx } from '../utils/explorer'
 
 export default function ProposalsTable({ proposals, loading }) {
   const [expanded, setExpanded] = useState([])
@@ -27,7 +26,6 @@ export default function ProposalsTable({ proposals, loading }) {
     try {
       const committee = await getCommitteeWithSigner()
       const tx = await committee.vote(id, vote)
-      notifyTx(tx.hash)
       await tx.wait()
     } catch (err) {
       console.error('Vote failed', err)
@@ -42,7 +40,6 @@ export default function ProposalsTable({ proposals, loading }) {
     try {
       const committee = await getCommitteeWithSigner()
       const tx = await committee.claimReward(id)
-      notifyTx(tx.hash)
       await tx.wait()
     } catch (err) {
       console.error('Claim failed', err)
@@ -56,7 +53,6 @@ export default function ProposalsTable({ proposals, loading }) {
     try {
       const staking = await getStakingWithSigner()
       const tx = await staking.withdrawBond(poolId)
-      notifyTx(tx.hash)
       await tx.wait()
     } catch (err) {
       console.error('Withdraw bond failed', err)

--- a/frontend/app/components/StakeModal.js
+++ b/frontend/app/components/StakeModal.js
@@ -9,11 +9,12 @@ import { getERC20WithSigner, getTokenDecimals, getTokenSymbol } from "../../lib/
 import { getTokenLogo } from "../config/tokenNameMap"
 import Modal from "./Modal"
 import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
-import { notifyTx } from "../utils/explorer"
+import { getTxExplorerUrl } from "../utils/explorer"
 
 export default function StakeModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [txHash, setTxHash] = useState("")
   const [balance, setBalance] = useState("0")
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
@@ -65,7 +66,7 @@ export default function StakeModal({ isOpen, onClose }) {
         await approveTx.wait()
       }
       const tx = await staking.stake(value)
-      notifyTx(tx.hash)
+      setTxHash(tx.hash)
       await tx.wait()
       setAmount("")
       onClose()
@@ -163,6 +164,19 @@ export default function StakeModal({ isOpen, onClose }) {
             "Stake Tokens"
           )}
         </button>
+        {txHash && (
+          <p className="text-xs text-center mt-2">
+            Transaction submitted.{' '}
+            <a
+              href={getTxExplorerUrl(txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              View on block explorer
+            </a>
+          </p>
+        )}
       </div>
     </Modal>
   )

--- a/frontend/app/components/UnstakeModal.js
+++ b/frontend/app/components/UnstakeModal.js
@@ -9,11 +9,12 @@ import { getERC20WithSigner, getTokenDecimals, getTokenSymbol } from "../../lib/
 import { getTokenLogo } from "../config/tokenNameMap"
 import Modal from "./Modal"
 import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
-import { notifyTx } from "../utils/explorer"
+import { getTxExplorerUrl } from "../utils/explorer"
 
 export default function UnstakeModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [txHash, setTxHash] = useState("")
   const [balance, setBalance] = useState("0")
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
@@ -57,7 +58,7 @@ export default function UnstakeModal({ isOpen, onClose }) {
     try {
       const staking = await getStakingWithSigner()
       const tx = await staking.unstake(ethers.utils.parseUnits(amount, decimals))
-      notifyTx(tx.hash)
+      setTxHash(tx.hash)
       await tx.wait()
       setAmount("")
       onClose()
@@ -135,6 +136,19 @@ export default function UnstakeModal({ isOpen, onClose }) {
             "Unstake Tokens"
           )}
         </button>
+        {txHash && (
+          <p className="text-xs text-center mt-2">
+            Transaction submitted.{' '}
+            <a
+              href={getTxExplorerUrl(txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              View on block explorer
+            </a>
+          </p>
+        )}
       </div>
     </Modal>
   )


### PR DESCRIPTION
## Summary
- remove toast notifications
- show a link to the submitted transaction in each modal

## Testing
- `npm test` *(fails: cannot find module `vitest`)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854112b945c832ebf81dabaebb245eb