### PR TITLE
Fix claim fee and coverage dates

### DIFF
--- a/frontend/app/api/pools/list/route.ts
+++ b/frontend/app/api/pools/list/route.ts
@@ -179,7 +179,7 @@ export async function GET() {
         const rateRes = poolResults[2 * i + 1];
         if (!dataRes.success || !rateRes.success) continue;
         try {
-          const dataDec = poolRegistry.interface.decodeFunctionResult(
+        const dataDec = poolRegistry.interface.decodeFunctionResult(
             "getPoolData",
             dataRes.returnData
           );
@@ -196,6 +196,7 @@ export async function GET() {
               dataDec.capitalPendingWithdrawal ?? dataDec[3],
             isPaused: dataDec.isPaused ?? dataDec[4],
             feeRecipient: dataDec.feeRecipient ?? dataDec[5],
+            claimFeeBps: dataDec.claimFeeBps ?? dataDec[6],
             rateModel: rateDec[0],
           };
           const info = bnToString(rawInfo);


### PR DESCRIPTION
## Summary
- fetch `claimFeeBps` from the PoolRegistry in the pools API
- compute expiry dates client‑side using premium deposit values
- show claim fee percent dynamically on the claim form
- show `N/A` if a coverage has no expiry date

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68542dcde2e4832e87384cbfd9422e73