### PR TITLE
Fix tests after network access

### DIFF
--- a/test/CapitalPool.test.js
+++ b/test/CapitalPool.test.js
@@ -26,7 +26,7 @@ describe("CapitalPool", function () {
     const NOTICE_PERIOD = 1 * 24 * 60 * 60; // 1 day
 
     // --- Mock ABIs ---
-    const iYieldAdapterAbi = require("../contracts/CapitalPool.sol/IYieldAdapter.json").abi;
+    const iYieldAdapterAbi = require("../artifacts/contracts/interfaces/IYieldAdapter.sol/IYieldAdapter.json").abi;
     const iRiskManagerHookAbi = `[{"inputs":[{"internalType":"address","name":"_underwriter","type":"address"},{"internalType":"uint256","name":"_amount","type":"uint256"}],"name":"onCapitalDeposited","outputs":[],"stateMutability":"nonpayable","type":"function"}, {"inputs":[{"internalType":"address","name":"_underwriter","type":"address"},{"internalType":"uint256","name":"_principalComponent","type":"uint256"}],"name":"onWithdrawalRequested","outputs":[],"stateMutability":"nonpayable","type":"function"}, {"inputs":[{"internalType":"address","name":"_underwriter","type":"address"},{"internalType":"uint256","name":"_principalComponentRemoved","type":"uint256"},{"internalType":"bool","name":"_isFullWithdrawal","type":"bool"}],"name":"onCapitalWithdrawn","outputs":[],"stateMutability":"nonpayable","type":"function"}]`;
 
     beforeEach(async function () {
@@ -35,7 +35,7 @@ describe("CapitalPool", function () {
 
         // --- Deploy Mocks ---
         const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", ethers.parseUnits("1000000", 6));
+        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
         
         mockRiskManager = await deployMock(iRiskManagerHookAbi, owner);
         mockAdapter1 = await deployMock(iYieldAdapterAbi, owner);

--- a/test/PolicyManager.test.js
+++ b/test/PolicyManager.test.js
@@ -49,7 +49,7 @@ describe("PolicyManager", function () {
         mockRiskManager = await deployMock("IRiskManager_PM_Hook", iRiskManagerHookAbi, owner);
         
         const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", ethers.parseUnits("1000000", 6));
+        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
         
         // --- Deploy PolicyManager ---
         const PolicyManagerFactory = await ethers.getContractFactory("PolicyManager");

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -47,7 +47,7 @@ describe("RiskManager", function () {
         mockRewardDistributor = await deployMock(iRewardDistributorAbi, owner);
 
         const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", ethers.parseUnits("1000000", 6));
+        mockUsdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
         
         // --- Deploy RiskManager ---
         const RiskManagerFactory = await ethers.getContractFactory("RiskManager");


### PR DESCRIPTION
## Summary
- fix path to IYieldAdapter ABI in CapitalPool tests
- use decimals integer instead of parseUnits in tests

## Testing
- `npm run test:capitalPool` *(fails: Transaction reverted without a reason string)*
- `npm run test:catInsurancePool` *(fails: Transaction reverted without a reason string)*

------
https://chatgpt.com/codex/tasks/task_e_6854744ed5a0832ea65656c4dbee956e