### PR TITLE
Fix Staking hardhat tests

### DIFF
--- a/contracts/MaliciousERC20.sol
+++ b/contracts/MaliciousERC20.sol
@@ -1,0 +1,26 @@
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+contract MaliciousERC20 is ERC20 {
+    bool public failTransfer = false;
+    bool public failTransferFrom = false;
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    function setFailTransfer(bool _fail) public {
+        failTransfer = _fail;
+    }
+    function setFailTransferFrom(bool _fail) public {
+        failTransferFrom = _fail;
+    }
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        require(!failTransfer, "MaliciousERC20: transfer failed");
+        return super.transfer(to, amount);
+    }
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        require(!failTransferFrom, "MaliciousERC20: transferFrom failed");
+        return super.transferFrom(from, to, amount);
+    }
+}

--- a/contracts/MaliciousPoolRegistry.sol
+++ b/contracts/MaliciousPoolRegistry.sol
@@ -1,0 +1,18 @@
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+interface IRiskManager {
+    function allocateCapital(uint256[] calldata _poolIds) external;
+}
+contract MaliciousPoolRegistry {
+    address public riskManager;
+    function setRiskManager(address _rm) external {
+        riskManager = _rm;
+    }
+    function updateCapitalAllocation(uint256, address, uint256, bool) external {
+        IRiskManager(riskManager).allocateCapital(new uint256[](0));
+    }
+    function getPoolCount() external pure returns (uint256) {
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- correct MockERC20 deployment and mint tokens for staking tests
- add malicious contracts used during tests
- ensure failed transfers leave balances unchanged

## Testing
- `npx hardhat test test/Staking.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68547d6ba330832e9656453ae4fb4607