### PR TITLE
Fix CatInsurancePool tests

### DIFF
--- a/contracts/test/MockRewardDistributor.sol
+++ b/contracts/test/MockRewardDistributor.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/IRewardDistributor.sol";
+
+contract MockRewardDistributor is IRewardDistributor {
+    address public catPool;
+
+    mapping(uint256 => mapping(address => uint256)) public totalRewards;
+    mapping(uint256 => mapping(address => uint256)) public totalShares;
+
+    function setCatPool(address _catPool) external override {
+        catPool = _catPool;
+    }
+
+    function distribute(uint256 poolId, address rewardToken, uint256 rewardAmount, uint256 totalPledgeInPool) external override {
+        totalRewards[poolId][rewardToken] += rewardAmount;
+        totalShares[poolId][rewardToken] = totalPledgeInPool;
+    }
+
+    function claimForCatPool(address user, uint256 poolId, address rewardToken, uint256 userPledge) external override returns (uint256) {
+        uint256 reward = pendingRewards(user, poolId, rewardToken, userPledge);
+        if (reward > 0) {
+            totalRewards[poolId][rewardToken] -= reward;
+        }
+        return reward;
+    }
+
+    function claim(address, uint256, address, uint256) external override returns (uint256) {
+        return 0;
+    }
+
+    function updateUserState(address, uint256, address, uint256) external override {}
+
+    function pendingRewards(address, uint256 poolId, address rewardToken, uint256 userPledge) public view override returns (uint256) {
+        uint256 total = totalRewards[poolId][rewardToken];
+        uint256 shares = totalShares[poolId][rewardToken];
+        if (shares == 0) return 0;
+        return total * userPledge / shares;
+    }
+}

--- a/test/Committee.test.js
+++ b/test/Committee.test.js
@@ -27,8 +27,8 @@ describe("Committee", function () {
     const SLASH_BPS = 500; // 5%
 
     // --- Mock ABIs ---
-    const iRiskManagerAbi = require("../artifacts/contracts/Committee.sol/IRiskManager.json").abi;
-    const iStakingContractAbi = require("../artifacts/contracts/Committee.sol/IStakingContract.json").abi;
+    const iRiskManagerAbi = require("../artifacts/contracts/interfaces/IRiskManager.sol/IRiskManager.json").abi;
+    const iStakingContractAbi = require("../artifacts/contracts/interfaces/IStakingContract.sol/IStakingContract.json").abi;
     const erc20Abi = require("@openzeppelin/contracts/build/contracts/ERC20.json").abi;
 
 

--- a/test/PolicyManager.test.js
+++ b/test/PolicyManager.test.js
@@ -27,12 +27,12 @@ describe("PolicyManager", function () {
     const COOLDOWN_PERIOD = 5 * 24 * 60 * 60; // 5 days
 
     // --- Mock ABIs ---
-    const iPoolRegistryAbi = require("../artifacts/contracts/PolicyManager.sol/IPoolRegistry.json").abi;
-    const iCapitalPoolAbi = require("../artifacts/contracts/PolicyManager.sol/ICapitalPool.json").abi;
-    const iCatInsurancePoolAbi = require("../artifacts/contracts/PolicyManager.sol/ICatInsurancePool.json").abi;
-    const iPolicyNFTAbi = require("../artifacts/contracts/PolicyManager.sol/IPolicyNFT.json").abi;
-    const iRewardDistributorAbi = require("../artifacts/contracts/PolicyManager.sol/IRewardDistributor.json").abi;
-    const iRiskManagerHookAbi = require("../artifacts/contracts/PolicyManager.sol/IRiskManager_PM_Hook.json").abi;
+    const iPoolRegistryAbi = require("../artifacts/contracts/interfaces/IPoolRegistry.sol/IPoolRegistry.json").abi;
+    const iCapitalPoolAbi = require("../artifacts/contracts/interfaces/ICapitalPool.sol/ICapitalPool.json").abi;
+    const iCatInsurancePoolAbi = require("../artifacts/contracts/interfaces/ICatInsurancePool.sol/ICatInsurancePool.json").abi;
+    const iPolicyNFTAbi = require("../artifacts/contracts/interfaces/IPolicyNFT.sol/IPolicyNFT.json").abi;
+    const iRewardDistributorAbi = require("../artifacts/contracts/interfaces/IRewardDistributor.sol/IRewardDistributor.json").abi;
+    const iRiskManagerHookAbi = require("../artifacts/contracts/interfaces/IRiskManager_PM_Hook.sol/IRiskManager_PM_Hook.json").abi;
     const erc20Abi = require("@openzeppelin/contracts/build/contracts/ERC20.json").abi;
 
 

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -24,13 +24,13 @@ describe("RiskManager", function () {
     const MAX_ALLOCATIONS = 5;
 
     // --- Mock ABIs (assuming they are generated in the artifacts folder) ---
-    const iPoolRegistryAbi = require("../artifacts/contracts/RiskManager.sol/IPoolRegistry.json").abi;
-    const iCapitalPoolAbi = require("../artifacts/contracts/RiskManager.sol/ICapitalPool.json").abi;
-    const iPolicyNFTAbi = require("../artifacts/contracts/RiskManager.sol/IPolicyNFT.json").abi;
-    const iCatInsurancePoolAbi = require("../artifacts/contracts/RiskManager.sol/ICatInsurancePool.json").abi;
-    const iLossDistributorAbi = require("../artifacts/contracts/RiskManager.sol/ILossDistributor.json").abi;
-    const iPolicyManagerAbi = require("../artifacts/contracts/RiskManager.sol/IPolicyManager.json").abi;
-    const iRewardDistributorAbi = require("../artifacts/contracts/RiskManager.sol/IRewardDistributor.json").abi;
+    const iPoolRegistryAbi = require("../artifacts/contracts/interfaces/IPoolRegistry.sol/IPoolRegistry.json").abi;
+    const iCapitalPoolAbi = require("../artifacts/contracts/interfaces/ICapitalPool.sol/ICapitalPool.json").abi;
+    const iPolicyNFTAbi = require("../artifacts/contracts/interfaces/IPolicyNFT.sol/IPolicyNFT.json").abi;
+    const iCatInsurancePoolAbi = require("../artifacts/contracts/interfaces/ICatInsurancePool.sol/ICatInsurancePool.json").abi;
+    const iLossDistributorAbi = require("../artifacts/contracts/interfaces/ILossDistributor.sol/ILossDistributor.json").abi;
+    const iPolicyManagerAbi = require("../artifacts/contracts/interfaces/IPolicyManager.sol/IPolicyManager.json").abi;
+    const iRewardDistributorAbi = require("../artifacts/contracts/interfaces/IRewardDistributor.sol/IRewardDistributor.json").abi;
 
 
     beforeEach(async function () {


### PR DESCRIPTION
## Summary
- use Solidity-based mocks instead of waffle mocks
- deploy and initialize CatInsurancePool correctly in tests
- add MockRewardDistributor contract for tests
- adjust withdrawal and reward calculations
- expect custom reentrancy error

## Testing
- `npm run test:catInsurancePool`


------
https://chatgpt.com/codex/tasks/task_e_68547d53e9d4832e9c9b9784d7d83aaf