### PR TITLE
Fix Committee tests

### DIFF
--- a/contracts/test/MockGovernanceRiskManager.sol
+++ b/contracts/test/MockGovernanceRiskManager.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "../interfaces/IRiskManager.sol";
+contract MockGovernanceRiskManager is IRiskManager {
+    uint256 public lastReportPoolId;
+    bool public lastPauseState;
+    uint256 public lastFeePoolId;
+    address public lastFeeRecipient;
+    function reportIncident(uint256 _poolId, bool _pauseState) external override {
+        lastReportPoolId = _poolId;
+        lastPauseState = _pauseState;
+    }
+    function setPoolFeeRecipient(uint256 _poolId, address _recipient) external override {
+        lastFeePoolId = _poolId;
+        lastFeeRecipient = _recipient;
+    }
+
+    function callReceiveFees(address committee, uint256 proposalId) external payable {
+        (bool ok,) = committee.call{value: msg.value}(abi.encodeWithSignature("receiveFees(uint256)", proposalId));
+        require(ok, "call failed");
+    }
+}

--- a/contracts/test/MockStakingContract.sol
+++ b/contracts/test/MockStakingContract.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "../interfaces/IStakingContract.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+contract MockStakingContract is IStakingContract {
+    IERC20 public govToken;
+    mapping(address => uint256) public balances;
+    constructor(IERC20 _gov) {
+        govToken = _gov;
+    }
+    function slash(address, uint256) external override {}
+    function stakedBalance(address user) external view override returns (uint256) {
+        return balances[user];
+    }
+    function governanceToken() external view override returns (IERC20) {
+        return govToken;
+    }
+    function setBalance(address user, uint256 amount) external {
+        balances[user] = amount;
+    }
+}


### PR DESCRIPTION
## Summary
- add test mocks for governance risk manager and staking contract
- update committee tests to use hardhat-deployed mocks
- adjust reward and reentrancy checks

## Testing
- `npx hardhat test test/Committee.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68547d3ada18832e9d8fbdc38b9d4560