### PR TITLE
Fix PoolRegistry tests

### DIFF
--- a/test/PoolRegistry.test.js
+++ b/test/PoolRegistry.test.js
@@ -37,35 +37,13 @@ describe("PoolRegistry", function () {
         await poolRegistry.waitForDeployment();
     });
 
-    // Mock ERC20 contract for testing purposes
-    const MockERC20Artifact = {
-        "contractName": "MockERC20",
-        "abi": [
-            {"inputs":[{"internalType":"string","name":"name","type":"string"},{"internalType":"string","name":"symbol","type":"string"},{"internalType":"uint256","name":"initialSupply","type":"uint256"}],"stateMutability":"nonpayable","type":"constructor"},
-            {"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Approval","type":"event"},
-            {"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Transfer","type":"event"},
-            {"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
-            {"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},
-            {"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
-            {"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},
-            {"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"subtractedValue","type":"uint256"}],"name":"decreaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},
-            {"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"addedValue","type":"uint256"}],"name":"increaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},
-            {"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},
-            {"inputs":[],"name":"symbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},
-            {"inputs":[],"name":"totalSupply","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
-            {"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},
-            {"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"transferFrom","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}
-        ],
-    };
-    
-    // We need to re-link the MockERC20 factory since we are using its artifact definition
-    ethers.ContractFactory.getContractFactory = async (name, signer) => {
-        if (name === "MockERC20") {
-            const factory = new ethers.ContractFactory(MockERC20Artifact.abi, MockERC20Artifact.bytecode, signer);
-            return factory;
-        }
-        return ethers.ContractFactory.getContractFactory(name, signer);
-    };
+    // Earlier versions of these tests attempted to manually construct a MockERC20
+    // contract factory using an inline artifact and by overriding
+    // `ethers.ContractFactory.getContractFactory`. The override caused infinite
+    // recursion with newer Hardhat versions, leading the tests to fail at
+    // startup. Hardhat already generates an artifact for `contracts/test/MockERC20.sol`,
+    // so we can simply rely on `ethers.getContractFactory` and remove the manual
+    // override entirely.
 
 
     describe("Deployment", function () {


### PR DESCRIPTION
## Summary
- simplify PoolRegistry tests by removing manual MockERC20 factory override

## Testing
- `npx hardhat test test/PoolRegistry.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685482765728832e9991ee5f92fabc3e