### PR TITLE
Fix Committee Hardhat tests

### DIFF
--- a/contracts/MaliciousRecipient.sol
+++ b/contracts/MaliciousRecipient.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+interface ICommittee {
+    function claimReward(uint256 _proposalId) external;
+}
+contract MaliciousRecipient {
+    ICommittee committee;
+    uint256 proposalId;
+    constructor(address _committee, uint256 _proposalId) payable {
+        committee = ICommittee(_committee);
+        proposalId = _proposalId;
+    }
+    function attack() external {
+        committee.claimReward(proposalId);
+    }
+    receive() external payable {
+        committee.claimReward(proposalId);
+    }
+}

--- a/contracts/test/MockCommitteeRiskManager.sol
+++ b/contracts/test/MockCommitteeRiskManager.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "../interfaces/IRiskManager.sol";
+
+contract MockCommitteeRiskManager is IRiskManager {
+    event IncidentReported(uint256 poolId, bool pauseState);
+    event FeeRecipientSet(uint256 poolId, address recipient);
+
+    function reportIncident(uint256 _poolId, bool _pauseState) external override {
+        emit IncidentReported(_poolId, _pauseState);
+    }
+
+    function setPoolFeeRecipient(uint256 _poolId, address _recipient) external override {
+        emit FeeRecipientSet(_poolId, _recipient);
+    }
+
+    function sendFees(address committee, uint256 proposalId) external payable {
+        (bool ok, ) = committee.call{value: msg.value}(abi.encodeWithSignature("receiveFees(uint256)", proposalId));
+        require(ok, "sendFees failed");
+    }
+}

--- a/contracts/test/MockCommitteeStaking.sol
+++ b/contracts/test/MockCommitteeStaking.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "../interfaces/IStakingContract.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockCommitteeStaking is IStakingContract {
+    IERC20 public immutable override governanceToken;
+    mapping(address => uint256) private balances;
+
+    constructor(IERC20 _token) {
+        governanceToken = _token;
+    }
+
+    function setBalance(address user, uint256 amount) external {
+        balances[user] = amount;
+    }
+
+    function slash(address, uint256) external override {}
+
+    function stakedBalance(address user) external view override returns (uint256) {
+        return balances[user];
+    }
+}


### PR DESCRIPTION
## Summary
- provide dedicated committee mocks
- rework Committee tests without smock
- ensure malicious test contract present

## Testing
- `npx hardhat test test/Committee.test.js`
- `npx hardhat test` *(fails: PolicyManager beforeEach)*

------
https://chatgpt.com/codex/tasks/task_e_6854829b007c832eaecba42d6274f489