### PR TITLE
Add solidity mocks for RiskManager tests

### DIFF
--- a/contracts/test/MockLossDistributor.sol
+++ b/contracts/test/MockLossDistributor.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/ILossDistributor.sol";
+
+/**
+ * @title MockLossDistributor
+ * @notice Simple mock implementing ILossDistributor for testing RiskManager.
+ * Allows tests to preset pending losses for a user and pool.
+ */
+contract MockLossDistributor is ILossDistributor {
+    mapping(address => mapping(uint256 => uint256)) public pending;
+
+    event LossDistributed(uint256 poolId, uint256 lossAmount, uint256 totalPledge);
+
+    function setPendingLoss(address user, uint256 poolId, uint256 amount) external {
+        pending[user][poolId] = amount;
+    }
+
+    function distributeLoss(uint256 poolId, uint256 lossAmount, uint256 totalPledgeInPool) external override {
+        emit LossDistributed(poolId, lossAmount, totalPledgeInPool);
+    }
+
+    function realizeLosses(address user, uint256 poolId, uint256) external override returns (uint256) {
+        uint256 amount = pending[user][poolId];
+        pending[user][poolId] = 0;
+        return amount;
+    }
+
+    function getPendingLosses(address user, uint256 poolId, uint256) external view override returns (uint256) {
+        return pending[user][poolId];
+    }
+}

--- a/contracts/test/MockPolicyManager.sol
+++ b/contracts/test/MockPolicyManager.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/IPolicyManager.sol";
+import "../interfaces/IPolicyNFT.sol";
+
+/**
+ * @title MockPolicyManager
+ * @notice Minimal PolicyManager mock exposing the policyNFT address.
+ */
+contract MockPolicyManager is IPolicyManager {
+    IPolicyNFT private _policyNFT;
+
+    function setPolicyNFT(address nft) external {
+        _policyNFT = IPolicyNFT(nft);
+    }
+
+    function policyNFT() external view override returns (IPolicyNFT) {
+        return _policyNFT;
+    }
+}


### PR DESCRIPTION
## Summary
- create `MockLossDistributor` and `MockPolicyManager`
- extend `MockCapitalPool` and `MockPoolRegistry`
- refactor `RiskManager.test.js` to use the Solidity mocks

## Testing
- `npx hardhat test test/RiskManager.test.js` *(fails: reverted with reason 'call failed')*

------
https://chatgpt.com/codex/tasks/task_e_685489b1ef8c832e80648b62be43549c