### PR TITLE
Expand RiskManager test coverage

### DIFF
--- a/contracts/test/MockCatInsurancePool.sol
+++ b/contracts/test/MockCatInsurancePool.sol
@@ -27,6 +27,8 @@ contract MockCatInsurancePool is Ownable {
     uint256 public receiveUsdcPremiumCallCount;
     uint256 public drawFundCallCount;
     uint256 public receiveProtocolAssetsCallCount;
+    address public last_claimProtocolToken;
+    uint256 public claimProtocolRewardsCallCount;
 
     // --- Events for Testing ---
 
@@ -91,5 +93,10 @@ contract MockCatInsurancePool is Ownable {
         last_distressedAssetReceived_amount = amount;
         receiveProtocolAssetsCallCount++;
         emit DistressedAssetReceivedCalled(address(protocolAsset), amount);
+    }
+
+    function claimProtocolAssetRewards(address protocolToken) external {
+        last_claimProtocolToken = protocolToken;
+        claimProtocolRewardsCallCount++;
     }
 }

--- a/contracts/test/MockRewardDistributor.sol
+++ b/contracts/test/MockRewardDistributor.sol
@@ -8,6 +8,11 @@ contract MockRewardDistributor is IRewardDistributor {
 
     mapping(uint256 => mapping(address => uint256)) public totalRewards;
     mapping(uint256 => mapping(address => uint256)) public totalShares;
+    address public lastClaimUser;
+    uint256 public lastClaimPoolId;
+    address public lastClaimToken;
+    uint256 public lastClaimPledge;
+    uint256 public claimCallCount;
 
     function setCatPool(address _catPool) external override {
         catPool = _catPool;
@@ -26,7 +31,12 @@ contract MockRewardDistributor is IRewardDistributor {
         return reward;
     }
 
-    function claim(address, uint256, address, uint256) external override returns (uint256) {
+    function claim(address user, uint256 poolId, address rewardToken, uint256 userPledge) external override returns (uint256) {
+        lastClaimUser = user;
+        lastClaimPoolId = poolId;
+        lastClaimToken = rewardToken;
+        lastClaimPledge = userPledge;
+        claimCallCount++;
         return 0;
     }
 


### PR DESCRIPTION
## Summary
- add reward claim tracking to mock contracts
- cover admin setter edge cases
- test positive hooks like onCapitalDeposited and onWithdrawalRequested
- verify reward claiming helpers

## Testing
- `npm run test:RiskManager`

------
https://chatgpt.com/codex/tasks/task_e_6854992619c8832e85c9edf5de69243e