### PR TITLE
Enhance CapitalPool payout tests

### DIFF
--- a/contracts/test/RevertingAdapter.sol
+++ b/contracts/test/RevertingAdapter.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../interfaces/IYieldAdapter.sol";
+import "../interfaces/IYieldAdapterEmergency.sol";
+
+contract RevertingAdapter is IYieldAdapter, IYieldAdapterEmergency {
+    IERC20 public immutable override asset;
+    constructor(IERC20 _asset) {
+        asset = _asset;
+    }
+    function deposit(uint256 amount) external override {}
+    function withdraw(uint256, address) external pure override returns (uint256) {
+        revert("RevertingAdapter: withdraw failed");
+    }
+    function emergencyTransfer(address to, uint256 amount) external override returns (uint256) {
+        uint256 bal = asset.balanceOf(address(this));
+        uint256 amt = bal < amount ? bal : amount;
+        if(amt > 0){
+            asset.transfer(to, amt);
+        }
+        return amt;
+    }
+    function getCurrentValueHeld() external view override returns (uint256) {
+        return asset.balanceOf(address(this));
+    }
+}

--- a/contracts/test/RevertingAdapterNoTransfer.sol
+++ b/contracts/test/RevertingAdapterNoTransfer.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../interfaces/IYieldAdapter.sol";
+import "../interfaces/IYieldAdapterEmergency.sol";
+
+contract RevertingAdapterNoTransfer is IYieldAdapter, IYieldAdapterEmergency {
+    IERC20 public immutable override asset;
+    constructor(IERC20 _asset) { asset = _asset; }
+    function deposit(uint256) external override {}
+    function withdraw(uint256, address) external pure override returns (uint256) {
+        revert("RevertingAdapter: withdraw failed");
+    }
+    function emergencyTransfer(address, uint256) external pure override returns (uint256) {
+        return 0;
+    }
+    function getCurrentValueHeld() external view override returns (uint256) {
+        return asset.balanceOf(address(this));
+    }
+}


### PR DESCRIPTION
## Summary
- create RevertingAdapter test contracts
- add tests for emergency payout flows in CapitalPool

## Testing
- `npx hardhat test test/CapitalPool.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685499e06af4832e845391aa2b9a3897