### PR TITLE
Add additional LossDistributor test

### DIFF
--- a/test/LossDistributor.test.js
+++ b/test/LossDistributor.test.js
@@ -299,5 +299,30 @@ describe("LossDistributor", function () {
         )
       ).to.equal(50n);
     });
+
+    it("Handles zero pledge when realizing losses", async function () {
+      const { riskManager, user, lossDistributor } = await loadFixture(
+        deployFixture
+      );
+      await lossDistributor
+        .connect(riskManager)
+        .distributeLoss(poolId, 100n, pledge);
+
+      const pending = await lossDistributor
+        .connect(riskManager)
+        .getFunction("realizeLosses")
+        .staticCall(user.address, poolId, 0);
+      expect(pending).to.equal(0n);
+
+      await (
+        await lossDistributor
+          .connect(riskManager)
+          .realizeLosses(user.address, poolId, 0)
+      ).wait();
+
+      expect(
+        await lossDistributor.userLossStates(user.address, poolId)
+      ).to.equal(0n);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add test for realizing losses with zero user pledge

## Testing
- `npx hardhat test test/LossDistributor.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68549a0bd4a8832ebc4b749e6af11d93