### PR TITLE
Add missing admin access test

### DIFF
--- a/test/CapitalPool.test.js
+++ b/test/CapitalPool.test.js
@@ -103,6 +103,12 @@ describe("CapitalPool", function () {
         .to.be.revertedWith("CP: Adapter address is not a contract");
     });
 
+    it("setBaseYieldAdapter restricted to owner", async () => {
+      await expect(capitalPool.connect(user1).setBaseYieldAdapter(YIELD_PLATFORM_1, mockAdapter1.target))
+        .to.be.revertedWithCustomError(capitalPool, "OwnableUnauthorizedAccount")
+        .withArgs(user1.address);
+    });
+
     it("setUnderwriterNoticePeriod restricted to owner", async () => {
       await expect(capitalPool.connect(user1).setUnderwriterNoticePeriod(1))
         .to.be.revertedWithCustomError(capitalPool, "OwnableUnauthorizedAccount")


### PR DESCRIPTION
## Summary
- ensure `setBaseYieldAdapter` reverts for non-owners

## Testing
- `npm run test:capitalPool`

------
https://chatgpt.com/codex/tasks/task_e_68549ee5f844832e82ae6ba39bc95898