### PR TITLE
Expand Staking forge tests

### DIFF
--- a/foundry/test/Staking.t.sol
+++ b/foundry/test/Staking.t.sol
@@ -4,22 +4,32 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 import {StakingContract} from "contracts/governance/Staking.sol";
 import {MockERC20} from "contracts/test/MockERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract StakingTest is Test {
     StakingContract staking;
     MockERC20 token;
 
+    event Staked(address indexed user, uint256 amount);
+    event Unstaked(address indexed user, uint256 amount);
+    event CommitteeAddressSet(address indexed committeeAddress);
+
     address owner = address(0x1);
     address committee = address(0x2);
     address staker = address(0x3);
+    address otherStaker = address(0x4);
 
     function setUp() public {
         token = new MockERC20("Gov", "GOV", 18);
         token.mint(staker, 1000 ether);
+        token.mint(otherStaker, 1000 ether);
 
         staking = new StakingContract(address(token), owner);
 
         vm.prank(staker);
+        token.approve(address(staking), type(uint256).max);
+
+        vm.prank(otherStaker);
         token.approve(address(staking), type(uint256).max);
     }
 
@@ -73,5 +83,107 @@ contract StakingTest is Test {
         vm.prank(staker);
         vm.expectRevert(StakingContract.NotCommittee.selector);
         staking.slash(staker, 5 ether);
+    }
+
+    function testStakeZeroReverts() public {
+        vm.prank(staker);
+        vm.expectRevert(StakingContract.InvalidAmount.selector);
+        staking.stake(0);
+    }
+
+    function testUnstakeZeroReverts() public {
+        vm.startPrank(staker);
+        staking.stake(10 ether);
+        vm.expectRevert(StakingContract.InvalidAmount.selector);
+        staking.unstake(0);
+        vm.stopPrank();
+    }
+
+    function testSlashZeroReverts() public {
+        vm.prank(owner);
+        staking.setCommitteeAddress(committee);
+
+        vm.prank(staker);
+        staking.stake(10 ether);
+
+        vm.prank(committee);
+        vm.expectRevert(StakingContract.InvalidAmount.selector);
+        staking.slash(staker, 0);
+    }
+
+    function testSlashMoreThanStakedReverts() public {
+        vm.prank(owner);
+        staking.setCommitteeAddress(committee);
+
+        vm.prank(staker);
+        staking.stake(10 ether);
+
+        vm.prank(committee);
+        vm.expectRevert(StakingContract.InsufficientStakedBalance.selector);
+        staking.slash(staker, 20 ether);
+    }
+
+    function testSlashNoStakeReverts() public {
+        vm.prank(owner);
+        staking.setCommitteeAddress(committee);
+
+        vm.prank(committee);
+        vm.expectRevert(StakingContract.InsufficientStakedBalance.selector);
+        staking.slash(staker, 1 ether);
+    }
+
+    function testSetCommitteeAddressOnlyOwner() public {
+        vm.prank(staker);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, staker)
+        );
+        staking.setCommitteeAddress(committee);
+
+        vm.prank(owner);
+        staking.setCommitteeAddress(committee);
+        assertEq(staking.committeeAddress(), committee);
+    }
+
+    function testSetCommitteeAddressTwiceReverts() public {
+        vm.prank(owner);
+        staking.setCommitteeAddress(committee);
+
+        vm.prank(owner);
+        vm.expectRevert(bytes("Committee address already set"));
+        staking.setCommitteeAddress(address(0x5));
+    }
+
+    function testSetCommitteeAddressZeroAddressReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(StakingContract.ZeroAddress.selector);
+        staking.setCommitteeAddress(address(0));
+    }
+
+    function testStakeEmitsEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit Staked(staker, 100 ether);
+        vm.prank(staker);
+        staking.stake(100 ether);
+    }
+
+    function testUnstakeEmitsEvent() public {
+        vm.startPrank(staker);
+        staking.stake(50 ether);
+        vm.expectEmit(true, false, false, true);
+        emit Unstaked(staker, 20 ether);
+        staking.unstake(20 ether);
+        vm.stopPrank();
+    }
+
+    function testMultipleStakersTotal() public {
+        vm.prank(staker);
+        staking.stake(40 ether);
+
+        vm.prank(otherStaker);
+        staking.stake(60 ether);
+
+        assertEq(staking.totalStaked(), 100 ether);
+        assertEq(staking.stakedBalance(staker), 40 ether);
+        assertEq(staking.stakedBalance(otherStaker), 60 ether);
     }
 }


### PR DESCRIPTION
## Summary
- extend Staking forge tests to cover more edge cases
- install forge-std during testing

## Testing
- `forge test --match-contract StakingTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_68551ad5bdcc832e97f3b80fc78b999f