### PR TITLE
Add capital deallocation request flow

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -39,10 +39,13 @@ contract RiskManager is Ownable, ReentrancyGuard {
     mapping(address => uint256[]) public underwriterAllocations;
     mapping(address => mapping(uint256 => bool)) public isAllocatedToPool;
     mapping(uint256 => mapping(address => uint256)) public underwriterIndexInPoolArray;
-    
+
     uint256 public maxAllocationsPerUnderwriter = 5;
     uint256 public constant CLAIM_FEE_BPS = 500;
     uint256 public constant BPS = 10_000;
+
+    uint256 public deallocationNoticePeriod;
+    mapping(address => mapping(uint256 => uint256)) public deallocationRequestTimestamp;
 
     /* ───────────────────────── Errors & Events ───────────────────────── */
     error NotCapitalPool();
@@ -55,12 +58,18 @@ contract RiskManager is Ownable, ReentrancyGuard {
     error NotAllocated();
     error UnderwriterNotInsolvent();
     error ZeroAddressNotAllowed();
+    error DeallocationRequestPending();
+    error NoDeallocationRequest();
+    error NoticePeriodActive();
+    error InsufficientFreeCapital();
 
     event AddressesSet(address capital, address registry, address policy, address cat, address loss, address rewards);
     event CommitteeSet(address committee);
     event UnderwriterLiquidated(address indexed liquidator, address indexed underwriter);
     event CapitalAllocated(address indexed underwriter, uint256 indexed poolId, uint256 amount);
     event CapitalDeallocated(address indexed underwriter, uint256 indexed poolId, uint256 amount);
+    event DeallocationRequested(address indexed underwriter, uint256 indexed poolId, uint256 timestamp);
+    event DeallocationNoticePeriodSet(uint256 newPeriod);
     event MaxAllocationsPerUnderwriterSet(uint256 newMax);
 
     /* ───────────────────── Constructor & Setup ───────────────────── */
@@ -97,6 +106,11 @@ contract RiskManager is Ownable, ReentrancyGuard {
         require(_newMax > 0, "Invalid max");
         maxAllocationsPerUnderwriter = _newMax;
         emit MaxAllocationsPerUnderwriterSet(_newMax);
+    }
+
+    function setDeallocationNoticePeriod(uint256 _newPeriod) external onlyOwner {
+        deallocationNoticePeriod = _newPeriod;
+        emit DeallocationNoticePeriodSet(_newPeriod);
     }
 
     /**
@@ -139,22 +153,47 @@ contract RiskManager is Ownable, ReentrancyGuard {
         }
     }
     
-    function deallocateFromPool(uint256 _poolId) external nonReentrant {
+    function requestDeallocateFromPool(uint256 _poolId) external nonReentrant {
         address underwriter = msg.sender;
-        _realizeLossesForAllPools(underwriter);
-        
-        uint256 totalPledge = underwriterTotalPledge[underwriter];
-        if (totalPledge == 0) revert NoCapitalToAllocate();
-        
         uint256 poolCount = poolRegistry.getPoolCount();
         require(_poolId < poolCount, "Invalid poolId");
         require(isAllocatedToPool[underwriter][_poolId], "Not allocated to this pool");
-        
+        if (deallocationRequestTimestamp[underwriter][_poolId] != 0) revert DeallocationRequestPending();
+
+        uint256 totalPledge = underwriterTotalPledge[underwriter];
+        if (totalPledge == 0) revert NoCapitalToAllocate();
+
+        (, uint256 totalPledged, uint256 totalSold, uint256 pendingWithdrawal,, ,) = poolRegistry.getPoolData(_poolId);
+        uint256 freeCapital = totalPledged > totalSold + pendingWithdrawal ? totalPledged - totalSold - pendingWithdrawal : 0;
+        if (totalPledge > freeCapital) revert InsufficientFreeCapital();
+
+        poolRegistry.updateCapitalPendingWithdrawal(_poolId, totalPledge, true);
+        deallocationRequestTimestamp[underwriter][_poolId] = block.timestamp;
+        emit DeallocationRequested(underwriter, _poolId, block.timestamp);
+    }
+
+    function deallocateFromPool(uint256 _poolId) external nonReentrant {
+        address underwriter = msg.sender;
+        uint256 requestTime = deallocationRequestTimestamp[underwriter][_poolId];
+        if (requestTime == 0) revert NoDeallocationRequest();
+        if (block.timestamp < requestTime + deallocationNoticePeriod) revert NoticePeriodActive();
+
+        _realizeLossesForAllPools(underwriter);
+
+        uint256 totalPledge = underwriterTotalPledge[underwriter];
+        if (totalPledge == 0) revert NoCapitalToAllocate();
+
+        uint256 poolCount = poolRegistry.getPoolCount();
+        require(_poolId < poolCount, "Invalid poolId");
+        require(isAllocatedToPool[underwriter][_poolId], "Not allocated to this pool");
+
         address userAdapterAddress = capitalPool.getUnderwriterAdapterAddress(underwriter);
         require(userAdapterAddress != address(0), "User has no yield adapter set in CapitalPool");
-        
+
         poolRegistry.updateCapitalAllocation(_poolId, userAdapterAddress, totalPledge, false);
+        poolRegistry.updateCapitalPendingWithdrawal(_poolId, totalPledge, false);
         _removeUnderwriterFromPool(underwriter, _poolId);
+        delete deallocationRequestTimestamp[underwriter][_poolId];
 
         emit CapitalDeallocated(underwriter, _poolId, totalPledge);
     }

--- a/foundry/test/RiskManager.t.sol
+++ b/foundry/test/RiskManager.t.sol
@@ -66,6 +66,7 @@ contract RiskManagerTest is Test {
         cp.triggerOnCapitalDeposited(address(rm), underwriter, pledge);
         cp.setUnderwriterAdapterAddress(underwriter, address(1));
         pr.setPoolCount(1);
+        pr.setPoolData(0, token, pledge, 0, 0, false, address(0), 0);
 
         uint256[] memory pools = new uint256[](1);
         pools[0] = 0;
@@ -73,6 +74,8 @@ contract RiskManagerTest is Test {
         rm.allocateCapital(pools);
 
         ld.setPendingLoss(underwriter, 0, 0);
+        vm.prank(underwriter);
+        rm.requestDeallocateFromPool(0);
         vm.prank(underwriter);
         rm.deallocateFromPool(0);
 
@@ -104,6 +107,7 @@ function testAllocateCapitalRevertsInvalidPoolId() public {
     cp.triggerOnCapitalDeposited(address(rm), underwriter, 1000);
     cp.setUnderwriterAdapterAddress(underwriter, address(1));
     pr.setPoolCount(1);
+    pr.setPoolData(0, token, 1000, 0, 0, false, address(0), 0);
     uint256[] memory pools = new uint256[](1);
     pools[0] = 1;
     vm.prank(underwriter);
@@ -121,6 +125,8 @@ function testDeallocateRealizesLoss() public {
     rm.allocateCapital(pools);
 
     ld.setPendingLoss(underwriter, 0, 200);
+    vm.prank(underwriter);
+    rm.requestDeallocateFromPool(0);
     vm.prank(underwriter);
     rm.deallocateFromPool(0);
 

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -198,15 +198,18 @@ const MAX_ALLOCATIONS = 5;
             beforeEach(async function() {
                 await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, PLEDGE_AMOUNT);
                 await mockPoolRegistry.setPoolCount(1);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, PLEDGE_AMOUNT, 0, 0, false, ethers.ZeroAddress, 0);
                 await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
                 await riskManager.connect(underwriter1).allocateCapital([POOL_ID_1]);
+                await riskManager.connect(owner).setDeallocationNoticePeriod(0);
             });
 
             it("Should allow an underwriter to deallocate from a pool with no losses", async function() {
                 await mockLossDistributor.setPendingLoss(underwriter1.address, POOL_ID_1, 0);
+                await riskManager.connect(underwriter1).requestDeallocateFromPool(POOL_ID_1);
                 await expect(riskManager.connect(underwriter1).deallocateFromPool(POOL_ID_1))
                     .to.emit(riskManager, "CapitalDeallocated").withArgs(underwriter1.address, POOL_ID_1, PLEDGE_AMOUNT);
-                
+
                 const allocations = await getAllocations(underwriter1.address);
                 expect(allocations).to.be.empty;
             });
@@ -214,7 +217,7 @@ const MAX_ALLOCATIONS = 5;
             it("Should correctly apply losses before deallocating", async function() {
                 const lossAmount = ethers.parseUnits("1000", 6);
                 await mockLossDistributor.setPendingLoss(underwriter1.address, POOL_ID_1, lossAmount);
-                
+                await riskManager.connect(underwriter1).requestDeallocateFromPool(POOL_ID_1);
                 await riskManager.connect(underwriter1).deallocateFromPool(POOL_ID_1);
 
                 // Check that pledge was reduced before emitting the event
@@ -226,12 +229,26 @@ const MAX_ALLOCATIONS = 5;
                 await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter2.address, pledge);
                 await mockCapitalPool.setUnderwriterAdapterAddress(underwriter2.address, nonParty.address);
                 await mockLossDistributor.setPendingLoss(underwriter2.address, POOL_ID_1, 0);
-                await expect(riskManager.connect(underwriter2).deallocateFromPool(POOL_ID_1))
+                await expect(riskManager.connect(underwriter2).requestDeallocateFromPool(POOL_ID_1))
                     .to.be.revertedWith("Not allocated to this pool");
+            });
+
+            it("Should revert if executing without a request", async function() {
+                await expect(riskManager.connect(underwriter1).deallocateFromPool(POOL_ID_1))
+                    .to.be.revertedWithCustomError(riskManager, "NoDeallocationRequest");
+            });
+
+            it("Should revert if notice period not elapsed", async function() {
+                await riskManager.connect(owner).setDeallocationNoticePeriod(100);
+                await riskManager.connect(underwriter1).requestDeallocateFromPool(POOL_ID_1);
+                await expect(riskManager.connect(underwriter1).deallocateFromPool(POOL_ID_1))
+                    .to.be.revertedWithCustomError(riskManager, "NoticePeriodActive");
+                await riskManager.connect(owner).setDeallocationNoticePeriod(0);
             });
 
             it("Should revert if yield adapter address is missing", async function () {
                 await mockLossDistributor.setPendingLoss(underwriter1.address, POOL_ID_1, 0);
+                await riskManager.connect(underwriter1).requestDeallocateFromPool(POOL_ID_1);
                 await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, ethers.ZeroAddress);
                 await expect(riskManager.connect(underwriter1).deallocateFromPool(POOL_ID_1))
                     .to.be.revertedWith("User has no yield adapter set in CapitalPool");


### PR DESCRIPTION
## Summary
- add deallocation notice period and request mapping in RiskManager
- require request before deallocation
- add corresponding unit tests for Hardhat and Foundry

## Testing
- `npx hardhat test test/RiskManager.test.js`
- `forge test --match-path foundry/test/RiskManager.t.sol` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552e77f264832eb47af3aa1d26ecd2