### PR TITLE
Add total bonded display in dashboard

### DIFF
--- a/frontend/app/api/committee/user/[address]/route.ts
+++ b/frontend/app/api/committee/user/[address]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { getCommittee } from '../../../../../lib/committee'
+import deployments from '../../../../config/deployments'
+
+export async function GET(req: Request, { params }: { params: { address: string } }) {
+  try {
+    const url = new URL(req.url)
+    const depName = url.searchParams.get('deployment')
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0]
+    const committee = getCommittee(dep.committee, dep.name)
+
+    const addr = params.address.toLowerCase()
+    const count: bigint = await committee.proposalCounter()
+    let total = 0n
+    for (let i = 1n; i <= count; i++) {
+      const p = await committee.proposals(i)
+      if (p.proposer.toLowerCase() === addr && Number(p.status) !== 6) {
+        total += BigInt(p.bondAmount)
+      }
+    }
+    return NextResponse.json({ address: addr, totalBonded: total.toString() })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}

--- a/frontend/app/dashboard/page.js
+++ b/frontend/app/dashboard/page.js
@@ -17,6 +17,7 @@ import useCatPoolStats from "../../hooks/useCatPoolStats"
 import useStakingInfo from "../../hooks/useStakingInfo"
 import usePastProposals from "../../hooks/usePastProposals"
 import useActiveProposals from "../../hooks/useActiveProposals"
+import useBondedAmount from "../../hooks/useBondedAmount"
 import { ethers } from "ethers"
 
 export default function Dashboard() {
@@ -30,6 +31,7 @@ export default function Dashboard() {
   const { info: stakingInfo } = useStakingInfo(address)
   const { proposals: pastProposals } = usePastProposals()
   const { proposals: activeProposals } = useActiveProposals()
+  const { amount: bondedAmount } = useBondedAmount(address)
   const [isClaimingRewards, setIsClaimingRewards] = useState(false)
 
   const hasActiveCoverages = (policies || []).length > 0
@@ -210,8 +212,10 @@ export default function Dashboard() {
                 <div className="text-lg font-semibold">{activeProposals.length}</div>
               </div>
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-                <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">Past Bonds</div>
-                <div className="text-lg font-semibold">{pastProposals.length}</div>
+                <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">Total Bonded</div>
+                <div className="text-lg font-semibold">
+                  {Number(ethers.utils.formatUnits(bondedAmount || "0", 18)).toFixed(4)}
+                </div>
               </div>
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
                 <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">Claimable Rewards</div>

--- a/frontend/hooks/useBondedAmount.js
+++ b/frontend/hooks/useBondedAmount.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+
+export default function useBondedAmount(address) {
+  const [amount, setAmount] = useState('0')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!address) return
+    async function load() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/committee/user/${address}`)
+        if (!res.ok) throw new Error('Failed to load')
+        const data = await res.json()
+        setAmount(data.totalBonded || '0')
+      } catch (err) {
+        console.error('Failed to load bonded amount', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [address])
+
+  return { amount, loading }
+}


### PR DESCRIPTION
## Summary
- create API route to fetch user's bonded tokens
- add hook to load bonded amount
- display total bonded tokens in My Bonds widget instead of Past Bonds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556dd2a3bc832e8b1121b25a7d89dd