### PR TITLE
Fix invalid BigNumber error in CatPool modal

### DIFF
--- a/frontend/app/components/CatPoolModal.js
+++ b/frontend/app/components/CatPoolModal.js
@@ -26,6 +26,7 @@ export default function CatPoolModal({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [txHash, setTxHash] = useState("")
   const [balance, setBalance] = useState("0")
+  const [decimals, setDecimals] = useState(6)
   const [needsApproval, setNeedsApproval] = useState(false)
   const [isApproving, setIsApproving] = useState(false)
   const projected = amount ? (Number.parseFloat(amount) * (apr / 100)).toFixed(2) : "0"
@@ -35,6 +36,8 @@ export default function CatPoolModal({
   const handleAmountChange = (e) => {
     const value = e.target.value
     if (value === "" || /^\d*\.?\d*$/.test(value)) {
+      const parts = value.split(".")
+      if (decimals != null && parts[1] && parts[1].length > decimals) return
       setAmount(value)
       setUsdValue(value || "0")
     }
@@ -69,6 +72,7 @@ export default function CatPoolModal({
       }
       const human = ethers.utils.formatUnits(bal, dec)
       setBalance(human)
+      setDecimals(dec)
       return human
     } catch {
       setBalance("0")


### PR DESCRIPTION
## Summary
- add decimals state to `CatPoolModal`
- restrict user input precision based on token decimals
- store decimals when loading balance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556ee4e1c0832e8d85fc3e17b732d4