### PR TITLE
Fix cat pool deposit value parsing

### DIFF
--- a/frontend/app/components/CatPoolDeposits.js
+++ b/frontend/app/components/CatPoolDeposits.js
@@ -17,7 +17,12 @@ export default function CatPoolDeposits({ displayCurrency, refreshTrigger }) {
   }
 
   const shares = Number(ethers.utils.formatUnits(info.balance || "0", 18))
-  const value = Number(ethers.utils.formatUnits(info.value || "0", 6))
+  let value
+  try {
+    value = Number(ethers.utils.formatUnits(info.value || "0", 6))
+  } catch {
+    value = Number(info.value || 0)
+  }
 
   return (
     <div className="overflow-x-auto -mx-4 sm:mx-0">


### PR DESCRIPTION
## Summary
- handle decimal strings in cat pool deposits component

## Testing
- `npm test`
- `npm --prefix frontend test` *(fails: Error: Failed to resolve import "@/lib/utils" from various components)*

------
https://chatgpt.com/codex/tasks/task_e_685572e3adf0832eae329a673bcd4c23