### PR TITLE
Fix premium rate overflow

### DIFF
--- a/contracts/core/PolicyManager.sol
+++ b/contracts/core/PolicyManager.sol
@@ -221,10 +221,12 @@ function _settleAndDrainPremium(uint256 _policyId) internal {
     function _getPremiumRateBpsAnnual(uint256 _poolId) internal view returns (uint256) {
         (, uint256 totalPledged, uint256 totalSold, uint256 pendingWithdrawal, , ,) = poolRegistry.getPoolData(_poolId);
         
-        // Resolution: If pending withdrawals exceed or equal pledged capital, 
-        // there is no available capital. This check prevents an underflow revert.
+        // If pending withdrawals exceed or equal pledged capital, there is no
+        // available capital for calculating a premium rate.  Returning zero
+        // avoids overflow in callers while signalling that premiums should not
+        // accrue.
         if (pendingWithdrawal >= totalPledged) {
-            return type(uint256).max;
+            return 0;
         }
 
         uint256 availableCapital = totalPledged - pendingWithdrawal;

--- a/test/PolicyManager.test.js
+++ b/test/PolicyManager.test.js
@@ -808,7 +808,7 @@ describe("PolicyManager", function () {
                 expect(await policyManager.isPolicyActive(POLICY_ID)).to.be.true;
             });
 
-            it("Should revert when pool has no available capital", async function() {
+            it("Should return true when pool has no available capital", async function() {
                 const now = await time.latest();
                 await mockPolicyNFT.mock_setPolicy(
                     POLICY_ID,
@@ -835,7 +835,7 @@ describe("PolicyManager", function () {
                 const rateModel = { base: 100, slope1: 200, slope2: 500, kink: 8000 };
                 await mockPoolRegistry.setRateModel(POOL_ID, rateModel);
 
-                await expect(policyManager.isPolicyActive(POLICY_ID)).to.be.reverted;
+                expect(await policyManager.isPolicyActive(POLICY_ID)).to.be.true;
             });
         });
 


### PR DESCRIPTION
## Summary
- prevent `_getPremiumRateBpsAnnual` from returning `type(uint256).max`
- adjust unit test for zero available capital

## Testing
- `npx hardhat test`
- `forge test` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855c6b56860832ea646550c0f29707b