### PR TITLE
Update pool capital after claims

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -296,6 +296,15 @@ contract RiskManager is Ownable, ReentrancyGuard {
         
         capitalPool.executePayout(payoutData);
 
+        if (lossBorneByPool > 0 && totalCapitalPledged > 0) {
+            for (uint256 i = 0; i < adapters.length; i++) {
+                uint256 adapterLoss = (lossBorneByPool * capitalPerAdapter[i]) / totalCapitalPledged;
+                if (adapterLoss > 0) {
+                    poolRegistry.updateCapitalAllocation(poolId, adapters[i], adapterLoss, false);
+                }
+            }
+        }
+
         // Update coverage sold directly without going through the PolicyManager
         // hook to avoid the NotPolicyManager revert when processing claims.
         (, , uint256 totalCoverageSold,, , ,) = poolRegistry.getPoolData(poolId);

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -359,6 +359,15 @@ const MAX_ALLOCATIONS = 5;
                 const stored = await mockRewardDistributor.totalRewards(POOL_ID_1, highDecToken.target);
                 expect(stored).to.equal(ethers.parseUnits("50000", 18));
             });
+
+            it("Should reduce pool capital after a claim", async function () {
+                const initial = (await mockPoolRegistry.pools(POOL_ID_1)).totalCapitalPledgedToPool;
+                await expect(riskManager.connect(nonParty).processClaim(POLICY_ID)).to.not.be.reverted;
+                const poolAfter = await mockPoolRegistry.pools(POOL_ID_1);
+                expect(poolAfter.totalCapitalPledgedToPool).to.equal(initial - COVERAGE_AMOUNT);
+                const capPerAdapter = await mockPoolRegistry.capitalPerAdapter(POOL_ID_1, nonParty.address);
+                expect(capPerAdapter).to.equal(initial - COVERAGE_AMOUNT);
+            });
         });
 
         describe("Liquidation", function() {


### PR DESCRIPTION
## Summary
- track adapter capital in MockPoolRegistry
- reduce pool capital immediately after claim processing
- test that pool capital decreases upon claim

## Testing
- `npm run test:RiskManager`

------
https://chatgpt.com/codex/tasks/task_e_6855c74e2f0c832e811c9bf255974ea1