### PR TITLE
Fix scaling for oracle decimals >18

### DIFF
--- a/contracts/oracles/PriceOracle.sol
+++ b/contracts/oracles/PriceOracle.sol
@@ -57,7 +57,12 @@ contract PriceOracle is Ownable {
         (int256 price, uint8 feedDecimals) = getLatestUsdPrice(token);
         if (price <= 0) return 0;
         uint8 tokenDecimals = IERC20Metadata(token).decimals();
-        uint256 scaledPrice = uint256(price) * (10 ** (18 - feedDecimals));
+        uint256 scaledPrice;
+        if (feedDecimals > 18) {
+            scaledPrice = uint256(price) / (10 ** (feedDecimals - 18));
+        } else {
+            scaledPrice = uint256(price) * (10 ** (18 - feedDecimals));
+        }
         value = (amount * scaledPrice) / (10 ** tokenDecimals);
     }
 }

--- a/test/PriceOracle.test.js
+++ b/test/PriceOracle.test.js
@@ -18,12 +18,36 @@ async function deployFixture() {
   return { Token, oracle };
 }
 
+async function deployLargeDecimalsFixture() {
+  const [owner] = await ethers.getSigners();
+  const ERC20 = await ethers.getContractFactory("MockERC20");
+  const Token = await ERC20.deploy("Mock Token", "MTK", 6);
+
+  const Aggregator = await ethers.getContractFactory("MockAggregator");
+  const price = 2000n * 10n ** 20n; // $2000 with 20 decimals
+  const aggregator = await Aggregator.deploy(price, 20);
+
+  const Oracle = await ethers.getContractFactory("PriceOracle");
+  const oracle = await Oracle.deploy(owner.address);
+  await oracle.setAggregator(Token.target, aggregator.target);
+
+  return { Token, oracle };
+}
+
 describe("PriceOracle", function () {
   it("calculates USD value", async function () {
     const { Token, oracle } = await loadFixture(deployFixture);
     const amount = 50n * 10n ** 6n; // 50 tokens with 6 decimals
     const usd = await oracle.getUsdValue(Token.target, amount);
     const expected = 100000n * 10n ** 18n; // $100,000 with 18 decimals
+    expect(usd).to.equal(expected);
+  });
+
+  it("handles feeds with decimals > 18", async function () {
+    const { Token, oracle } = await loadFixture(deployLargeDecimalsFixture);
+    const amount = 5n * 10n ** 6n; // 5 tokens with 6 decimals
+    const usd = await oracle.getUsdValue(Token.target, amount);
+    const expected = 10000n * 10n ** 18n; // $10,000 with 18 decimals
     expect(usd).to.equal(expected);
   });
 });


### PR DESCRIPTION
## Summary
- handle price feeds with more than 18 decimals
- add regression test using high-decimal mock aggregator

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855c75ea494832e8c8593d7a9c21095