### PR TITLE
Update reward tracking on deposits and withdrawals

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -332,6 +332,13 @@ contract RiskManager is Ownable, ReentrancyGuard {
         uint256[] memory pools = underwriterAllocations[_underwriter];
         for(uint i=0; i<pools.length; i++){
             underwriterPoolPledge[_underwriter][pools[i]] += _amount;
+            (IERC20 protocolToken,,,,,,) = poolRegistry.getPoolData(pools[i]);
+            rewardDistributor.updateUserState(
+                _underwriter,
+                pools[i],
+                address(protocolToken),
+                underwriterPoolPledge[_underwriter][pools[i]]
+            );
         }
     }
 
@@ -340,6 +347,13 @@ contract RiskManager is Ownable, ReentrancyGuard {
         uint256[] memory allocations = underwriterAllocations[_underwriter];
         for (uint i = 0; i < allocations.length; i++) {
             poolRegistry.updateCapitalPendingWithdrawal(allocations[i], _principalComponent, true);
+            (IERC20 protocolToken,,,,,,) = poolRegistry.getPoolData(allocations[i]);
+            rewardDistributor.updateUserState(
+                _underwriter,
+                allocations[i],
+                address(protocolToken),
+                underwriterPoolPledge[_underwriter][allocations[i]]
+            );
         }
     }
 
@@ -361,6 +375,13 @@ contract RiskManager is Ownable, ReentrancyGuard {
             }
             uint256 pledgeReduction = _principalComponentRemoved > underwriterPoolPledge[_underwriter][poolId] ? underwriterPoolPledge[_underwriter][poolId] : _principalComponentRemoved;
             underwriterPoolPledge[_underwriter][poolId] -= pledgeReduction;
+            (IERC20 protocolToken,,,,,,) = poolRegistry.getPoolData(poolId);
+            rewardDistributor.updateUserState(
+                _underwriter,
+                poolId,
+                address(protocolToken),
+                underwriterPoolPledge[_underwriter][poolId]
+            );
             if (_isFullWithdrawal || underwriterPoolPledge[_underwriter][poolId] == 0) {
                 _removeUnderwriterFromPool(_underwriter, poolId);
             }

--- a/contracts/test/MockRewardDistributor.sol
+++ b/contracts/test/MockRewardDistributor.sol
@@ -14,6 +14,12 @@ contract MockRewardDistributor is IRewardDistributor {
     uint256 public lastClaimPledge;
     uint256 public claimCallCount;
 
+    address public lastUpdateUser;
+    uint256 public lastUpdatePoolId;
+    address public lastUpdateToken;
+    uint256 public lastUpdatePledge;
+    uint256 public updateCallCount;
+
     function setCatPool(address _catPool) external override {
         catPool = _catPool;
     }
@@ -40,7 +46,13 @@ contract MockRewardDistributor is IRewardDistributor {
         return 0;
     }
 
-    function updateUserState(address, uint256, address, uint256) external override {}
+    function updateUserState(address user, uint256 poolId, address rewardToken, uint256 userPledge) external override {
+        lastUpdateUser = user;
+        lastUpdatePoolId = poolId;
+        lastUpdateToken = rewardToken;
+        lastUpdatePledge = userPledge;
+        updateCallCount++;
+    }
 
     function pendingRewards(address, uint256 poolId, address rewardToken, uint256 userPledge) public view override returns (uint256) {
         uint256 total = totalRewards[poolId][rewardToken];

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -486,6 +486,51 @@ const MAX_ALLOCATIONS = 5;
                 const allocs = await getAllocations(underwriter1.address);
                 expect(allocs).to.be.empty;
             });
+
+            it("onCapitalDeposited should update reward state for each pool", async function () {
+                const amount = ethers.parseUnits("500", 6);
+                await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, amount);
+                await mockPoolRegistry.setPoolCount(2);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, amount, 0, 0, false, committee.address, 0);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_2, mockUsdc.target, amount, 0, 0, false, committee.address, 0);
+                await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
+                await riskManager.connect(underwriter1).allocateCapital([POOL_ID_1, POOL_ID_2]);
+
+                await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, amount);
+
+                expect(await mockRewardDistributor.updateCallCount()).to.equal(2);
+                expect(await mockRewardDistributor.lastUpdateUser()).to.equal(underwriter1.address);
+            });
+
+            it("onWithdrawalRequested should snapshot reward state", async function () {
+                const amount = ethers.parseUnits("500", 6);
+                await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, amount);
+                await mockPoolRegistry.setPoolCount(1);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, amount, 0, 0, false, committee.address, 0);
+                await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
+                await riskManager.connect(underwriter1).allocateCapital([POOL_ID_1]);
+
+                await mockCapitalPool.triggerOnWithdrawalRequested(riskManager.target, underwriter1.address, amount);
+
+                expect(await mockRewardDistributor.updateCallCount()).to.equal(1);
+                expect(await mockRewardDistributor.lastUpdatePoolId()).to.equal(POOL_ID_1);
+            });
+
+            it("onCapitalWithdrawn should update reward state after withdrawal", async function () {
+                const pledge = ethers.parseUnits("1000", 6);
+                const withdraw = ethers.parseUnits("400", 6);
+                await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, pledge);
+                await mockPoolRegistry.setPoolCount(1);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, pledge, 0, 0, false, committee.address, 0);
+                await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
+                await riskManager.connect(underwriter1).allocateCapital([POOL_ID_1]);
+                await mockLossDistributor.setPendingLoss(underwriter1.address, POOL_ID_1, 0);
+
+                await mockCapitalPool.triggerOnCapitalWithdrawn(riskManager.target, underwriter1.address, withdraw, false);
+
+                expect(await mockRewardDistributor.updateCallCount()).to.equal(1);
+                expect(await mockRewardDistributor.lastUpdatePledge()).to.equal(pledge - withdraw);
+            });
         });
 
         describe("Reward Claims", function () {
@@ -507,6 +552,88 @@ const MAX_ALLOCATIONS = 5;
                 await riskManager.connect(nonParty).claimDistressedAssets(POOL_ID_1);
                 expect(await mockCatPool.claimProtocolRewardsCallCount()).to.equal(1);
                 expect(await mockCatPool.last_claimProtocolToken()).to.equal(mockUsdc.target);
+            });
+        });
+
+        describe("Reward accrual after deposits and withdrawals", function () {
+            let realRM, realRD;
+            const reward = ethers.parseUnits("100", 6);
+
+            beforeEach(async function () {
+                const RiskManagerFactory = await ethers.getContractFactory("RiskManager");
+                realRM = await RiskManagerFactory.deploy(owner.address);
+                const RDFactory = await ethers.getContractFactory("RewardDistributor");
+                realRD = await RDFactory.deploy(realRM.target);
+                await realRM.connect(owner).setAddresses(
+                    mockCapitalPool.target,
+                    mockPoolRegistry.target,
+                    mockPolicyManager.target,
+                    mockCatPool.target,
+                    mockLossDistributor.target,
+                    realRD.target
+                );
+                await mockUsdc.connect(owner).mint(realRD.target, ethers.parseUnits("1000", 6));
+                await realRM.connect(owner).setCommittee(committee.address);
+            });
+
+            async function distribute(amount, total) {
+                await ethers.provider.send("hardhat_impersonateAccount", [realRM.target]);
+                const signer = await ethers.getSigner(realRM.target);
+                await ethers.provider.send("hardhat_setBalance", [realRM.target, "0x1000000000000000000"]);
+                await realRD.connect(signer).distribute(POOL_ID_1, mockUsdc.target, amount, total);
+                await ethers.provider.send("hardhat_stopImpersonatingAccount", [realRM.target]);
+            }
+
+            it("accrues correctly after additional deposit", async function () {
+                const first = ethers.parseUnits("1000", 6);
+                const second = ethers.parseUnits("500", 6);
+
+                await mockCapitalPool.triggerOnCapitalDeposited(realRM.target, underwriter1.address, first);
+                await mockPoolRegistry.setPoolCount(1);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, first, 0, 0, false, committee.address, 0);
+                await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
+                await realRM.connect(underwriter1).allocateCapital([POOL_ID_1]);
+
+                await distribute(reward, first);
+                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+
+                await mockCapitalPool.triggerOnCapitalDeposited(realRM.target, underwriter1.address, second);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, first + second, 0, 0, false, committee.address, 0);
+
+                await distribute(reward, first + second);
+
+                const pledgeNow = await realRM.underwriterPoolPledge(underwriter1.address, POOL_ID_1);
+                const expected = await realRD.pendingRewards(underwriter1.address, POOL_ID_1, mockUsdc.target, pledgeNow);
+                const before = await mockUsdc.balanceOf(underwriter1.address);
+                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                const after = await mockUsdc.balanceOf(underwriter1.address);
+                expect(after - before).to.equal(expected);
+            });
+
+            it("accrues correctly after withdrawal", async function () {
+                const pledge = ethers.parseUnits("1000", 6);
+                const withdraw = ethers.parseUnits("400", 6);
+
+                await mockCapitalPool.triggerOnCapitalDeposited(realRM.target, underwriter1.address, pledge);
+                await mockPoolRegistry.setPoolCount(1);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, pledge, 0, 0, false, committee.address, 0);
+                await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
+                await realRM.connect(underwriter1).allocateCapital([POOL_ID_1]);
+
+                await distribute(reward, pledge);
+                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+
+                await mockLossDistributor.setPendingLoss(underwriter1.address, POOL_ID_1, 0);
+                await mockCapitalPool.triggerOnCapitalWithdrawn(realRM.target, underwriter1.address, withdraw, false);
+                await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, pledge - withdraw, 0, 0, false, committee.address, 0);
+
+                await distribute(reward, pledge - withdraw);
+                const pledgeNow = await realRM.underwriterPoolPledge(underwriter1.address, POOL_ID_1);
+                const expected = await realRD.pendingRewards(underwriter1.address, POOL_ID_1, mockUsdc.target, pledgeNow);
+                const before = await mockUsdc.balanceOf(underwriter1.address);
+                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                const after = await mockUsdc.balanceOf(underwriter1.address);
+                expect(after - before).to.equal(expected);
             });
         });
 


### PR DESCRIPTION
## Summary
- call `rewardDistributor.updateUserState` whenever pledge changes
- track updateUserState calls in `MockRewardDistributor`
- test reward state snapshots on deposit/withdraw
- verify rewards accrue correctly after deposits and withdrawals

## Testing
- `npx hardhat test test/RiskManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6855c6e2651c832eb33f1072520160f3