### PR TITLE
Add claim rewards for user in CatInsurancePool

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -337,7 +337,7 @@ contract RiskManager is Ownable, ReentrancyGuard {
 
     function claimDistressedAssets(uint256 _poolId) external nonReentrant {
         (IERC20 protocolToken,,,,,,) = poolRegistry.getPoolData(_poolId);
-        catPool.claimProtocolAssetRewards(address(protocolToken));
+        catPool.claimProtocolAssetRewardsFor(msg.sender, address(protocolToken));
     }
 
     function onCapitalDeposited(address _underwriter, uint256 _amount) external {

--- a/contracts/external/CatInsurancePool.sol
+++ b/contracts/external/CatInsurancePool.sol
@@ -267,11 +267,30 @@ contract CatInsurancePool is Ownable, ReentrancyGuard {
     function claimProtocolAssetRewards(address protocolAsset) external nonReentrant {
         require(address(rewardDistributor) != address(0), "CIP: Reward distributor not set");
         uint256 userShares = catShareToken.balanceOf(msg.sender);
-        
+
         uint256 claimableAmount = rewardDistributor.claimForCatPool(msg.sender, CAT_POOL_REWARD_ID, protocolAsset, userShares);
-        
+
         require(claimableAmount > 0, "CIP: No rewards to claim for this asset");
         emit ProtocolAssetRewardsClaimed(msg.sender, protocolAsset, claimableAmount);
+    }
+
+    function claimProtocolAssetRewardsFor(address user, address protocolAsset)
+        external
+        onlyRiskManager
+        nonReentrant
+    {
+        require(address(rewardDistributor) != address(0), "CIP: Reward distributor not set");
+        uint256 userShares = catShareToken.balanceOf(user);
+
+        uint256 claimableAmount = rewardDistributor.claimForCatPool(
+            user,
+            CAT_POOL_REWARD_ID,
+            protocolAsset,
+            userShares
+        );
+
+        require(claimableAmount > 0, "CIP: No rewards to claim for this asset");
+        emit ProtocolAssetRewardsClaimed(user, protocolAsset, claimableAmount);
     }
 
     /* ───────────────────── View Functions ───────────────────── */

--- a/contracts/interfaces/ICatInsurancePool.sol
+++ b/contracts/interfaces/ICatInsurancePool.sol
@@ -5,5 +5,6 @@ interface ICatInsurancePool {
     function drawFund(uint256 amount) external;
     function receiveUsdcPremium(uint256 amount) external;
     function claimProtocolAssetRewards(address protocolToken) external;
+    function claimProtocolAssetRewardsFor(address user, address protocolToken) external;
 }
 

--- a/contracts/test/MaliciousCatReentrant.sol
+++ b/contracts/test/MaliciousCatReentrant.sol
@@ -23,4 +23,6 @@ contract MaliciousCatReentrant is ICatInsurancePool {
     function drawFund(uint256) external override {}
 
     function claimProtocolAssetRewards(address) external override {}
+
+    function claimProtocolAssetRewardsFor(address, address) external override {}
 }

--- a/contracts/test/MockCatInsurancePool.sol
+++ b/contracts/test/MockCatInsurancePool.sol
@@ -29,6 +29,7 @@ contract MockCatInsurancePool is Ownable {
     uint256 public receiveProtocolAssetsCallCount;
     address public last_claimProtocolToken;
     uint256 public claimProtocolRewardsCallCount;
+    address public last_claimUser;
 
     // --- Events for Testing ---
 
@@ -97,6 +98,13 @@ contract MockCatInsurancePool is Ownable {
 
     function claimProtocolAssetRewards(address protocolToken) external {
         last_claimProtocolToken = protocolToken;
+        last_claimUser = msg.sender;
+        claimProtocolRewardsCallCount++;
+    }
+
+    function claimProtocolAssetRewardsFor(address user, address protocolToken) external {
+        last_claimProtocolToken = protocolToken;
+        last_claimUser = user;
         claimProtocolRewardsCallCount++;
     }
 }

--- a/frontend/abi/CatInsurancePool.json
+++ b/frontend/abi/CatInsurancePool.json
@@ -384,23 +384,41 @@
 		"stateMutability": "view",
 		"type": "function"
 	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "protocolAsset",
-				"type": "address"
-			}
-		],
-		"name": "claimProtocolAssetRewards",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "uint256",
+        {
+                "inputs": [
+                        {
+                                "internalType": "address",
+                                "name": "protocolAsset",
+                                "type": "address"
+                        }
+                ],
+                "name": "claimProtocolAssetRewards",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+        },
+        {
+                "inputs": [
+                        {
+                                "internalType": "address",
+                                "name": "user",
+                                "type": "address"
+                        },
+                        {
+                                "internalType": "address",
+                                "name": "protocolAsset",
+                                "type": "address"
+                        }
+                ],
+                "name": "claimProtocolAssetRewardsFor",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+        },
+        {
+                "inputs": [
+                        {
+                                "internalType": "uint256",
 				"name": "usdcAmount",
 				"type": "uint256"
 			}

--- a/subgraphs/insurance/abis/CatInsurancePool.json
+++ b/subgraphs/insurance/abis/CatInsurancePool.json
@@ -306,6 +306,24 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "protocolAsset",
+        "type": "address"
+      }
+    ],
+    "name": "claimProtocolAssetRewardsFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "coverPoolAddress",
     "outputs": [

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -565,6 +565,7 @@ const MAX_ALLOCATIONS = 5;
                 await riskManager.connect(nonParty).claimDistressedAssets(POOL_ID_1);
                 expect(await mockCatPool.claimProtocolRewardsCallCount()).to.equal(1);
                 expect(await mockCatPool.last_claimProtocolToken()).to.equal(mockUsdc.target);
+                expect(await mockCatPool.last_claimUser()).to.equal(nonParty.address);
             });
         });
 


### PR DESCRIPTION
## Summary
- extend CatInsurancePool with `claimProtocolAssetRewardsFor`
- update interface and ABI files
- hook RiskManager.claimDistressedAssets into the new method
- adjust Solidity mocks
- cover new behaviour in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685692dc1114832eabb1f5fec119f5db