### PR TITLE
Enforce policy activation when processing claims

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -266,6 +266,7 @@ contract RiskManager is Ownable, ReentrancyGuard {
 
     function processClaim(uint256 _policyId) external nonReentrant {
         IPolicyNFT.Policy memory policy = policyNFT.getPolicy(_policyId);
+        require(block.timestamp >= policy.activation, "Policy not active");
         uint256 poolId = policy.poolId;
         uint256 coverage = policy.coverage;
         (address[] memory adapters, uint256[] memory capitalPerAdapter, uint256 totalCapitalPledged) = poolRegistry.getPoolPayoutData(poolId);

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -371,6 +371,22 @@ const MAX_ALLOCATIONS = 5;
                 const capPerAdapter = await mockPoolRegistry.capitalPerAdapter(POOL_ID_1, nonParty.address);
                 expect(capPerAdapter).to.equal(initial - COVERAGE_AMOUNT);
             });
+
+            it("Should revert if claim is processed before activation", async function () {
+                const future = (await time.latest()) + 1000;
+                await mockPolicyNFT.mock_setPolicy(
+                    POLICY_ID,
+                    claimant.address,
+                    POOL_ID_1,
+                    COVERAGE_AMOUNT,
+                    future,
+                    0,
+                    0,
+                    0
+                );
+                await expect(riskManager.connect(nonParty).processClaim(POLICY_ID))
+                    .to.be.revertedWith("Policy not active");
+            });
         });
 
         describe("Liquidation", function() {


### PR DESCRIPTION
## Summary
- check policy activation time in `RiskManager.processClaim`
- test claim revert when processed before activation

## Testing
- `npm run test:RiskManager`

------
https://chatgpt.com/codex/tasks/task_e_685693118d84832e8e4775401247f1bb