### PR TITLE
Fix token approvals needing zero-reset

### DIFF
--- a/contracts/core/CapitalPool.sol
+++ b/contracts/core/CapitalPool.sol
@@ -148,6 +148,7 @@ contract CapitalPool is ReentrancyGuard, Ownable {
         account.totalDepositedAssetPrincipal += _amount;
         account.masterShares += sharesToMint;
         underlyingAsset.safeTransferFrom(msg.sender, address(this), _amount);
+        underlyingAsset.approve(address(chosenAdapter), 0);
         underlyingAsset.approve(address(chosenAdapter), _amount);
         chosenAdapter.deposit(_amount);
         totalMasterSharesSystem += sharesToMint;

--- a/contracts/core/PolicyManager.sol
+++ b/contracts/core/PolicyManager.sol
@@ -201,6 +201,7 @@ function _settleAndDrainPremium(uint256 _policyId) internal {
             IERC20 underlying = capitalPool.underlyingAsset();
 
             // Approve the Cat Pool to pull the premium amount
+            underlying.approve(address(catPool), 0);
             underlying.approve(address(catPool), catAmount);
 
             catPool.receiveUsdcPremium(catAmount);

--- a/contracts/test/ResetApproveERC20.sol
+++ b/contracts/test/ResetApproveERC20.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC20 token that requires allowance to be zero before being changed
+contract ResetApproveERC20 is ERC20 {
+    uint8 private immutable _mockDecimals;
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _mockDecimals = decimals_;
+    }
+    function decimals() public view override returns (uint8) {
+        return _mockDecimals;
+    }
+    function approve(address spender, uint256 amount) public override returns (bool) {
+        uint256 current = allowance(_msgSender(), spender);
+        if (amount != 0 && current != 0) {
+            revert("ResetApproveERC20: must set 0 first");
+        }
+        return super.approve(spender, amount);
+    }
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/test/ResetApproval.test.js
+++ b/test/ResetApproval.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("Reset approve tokens", function () {
+  it("CapitalPool supports tokens requiring allowance reset", async function () {
+    const [owner, user] = await ethers.getSigners();
+    const ResetToken = await ethers.getContractFactory("ResetApproveERC20");
+    const token = await ResetToken.deploy("Reset", "RST", 6);
+    await token.mint(user.address, ethers.parseUnits("10000", 6));
+
+    const MockAdapter = await ethers.getContractFactory("MockYieldAdapter");
+    const adapter = await MockAdapter.deploy(token.target, ethers.ZeroAddress, owner.address);
+    const MockRisk = await ethers.getContractFactory("MockRiskManager");
+    const risk = await MockRisk.deploy();
+
+    const CapitalPool = await ethers.getContractFactory("CapitalPool");
+    const pool = await CapitalPool.deploy(owner.address, token.target);
+    await pool.setRiskManager(risk.target);
+    await pool.setBaseYieldAdapter(1, adapter.target);
+    await adapter.setDepositor(pool.target);
+
+    const amt = ethers.parseUnits("1000", 6);
+    await token.connect(user).approve(pool.target, amt * 2n);
+
+    await pool.connect(user).deposit(amt, 1);
+    await expect(pool.connect(user).deposit(amt, 1)).to.not.be.reverted;
+  });
+
+  it("PolicyManager drains premium with reset token", async function () {
+    const [owner, user] = await ethers.getSigners();
+    const ResetToken = await ethers.getContractFactory("ResetApproveERC20");
+    const token = await ResetToken.deploy("Reset", "RST", 6);
+    await token.mint(user.address, ethers.parseUnits("10000", 6));
+
+    const MockPoolRegistry = await ethers.getContractFactory("MockPoolRegistry");
+    const MockCapitalPool = await ethers.getContractFactory("MockCapitalPool");
+    const MockCatInsurancePool = await ethers.getContractFactory("MockCatInsurancePool");
+    const MockPolicyNFT = await ethers.getContractFactory("MockPolicyNFT");
+    const MockRewardDistributor = await ethers.getContractFactory("MockRewardDistributor");
+    const MockRiskManager = await ethers.getContractFactory("MockRiskManagerHook");
+
+    const poolRegistry = await MockPoolRegistry.deploy();
+    const capitalPool = await MockCapitalPool.deploy(owner.address, token.target);
+    const catPool = await MockCatInsurancePool.deploy(owner.address);
+    const policyNFT = await MockPolicyNFT.deploy(owner.address);
+    const rewards = await MockRewardDistributor.deploy();
+    const risk = await MockRiskManager.deploy();
+
+    const PolicyManager = await ethers.getContractFactory("PolicyManager");
+    const pm = await PolicyManager.deploy(policyNFT.target, owner.address);
+    await policyNFT.setCoverPoolAddress(pm.target);
+    await pm.setAddresses(poolRegistry.target, capitalPool.target, catPool.target, rewards.target, risk.target);
+
+    await poolRegistry.setPoolData(0, token.target, ethers.parseUnits("100000", 6), 0, 0, false, owner.address, 0);
+    const rate = { base: 100, slope1: 200, slope2: 500, kink: 8000 };
+    await poolRegistry.setRateModel(0, rate);
+
+    await token.connect(user).approve(pm.target, ethers.MaxUint256);
+    await pm.connect(user).purchaseCover(0, ethers.parseUnits("10000", 6), ethers.parseUnits("100", 6));
+
+    await time.increase(24 * 60 * 60);
+    await token.connect(user).transfer(pm.target, ethers.parseUnits("100", 6));
+    await pm.connect(user).addPremium(1, ethers.parseUnits("1", 6));
+    await time.increase(24 * 60 * 60);
+    await token.connect(user).transfer(pm.target, ethers.parseUnits("100", 6));
+    await expect(pm.connect(user).addPremium(1, ethers.parseUnits("1", 6))).to.not.be.reverted;
+  });
+});


### PR DESCRIPTION
## Summary
- reset allowance before setting new approvals in `CapitalPool` and `PolicyManager`
- add `ResetApproveERC20` token for tests
- cover zero-reset behaviour in new Hardhat tests

## Testing
- `npx hardhat test test/ResetApproval.test.js`
- `forge test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685693b40174832e97a8e49cf6a6056b