### PR TITLE
Connect Manage Coverage modal to smart contracts

### DIFF
--- a/frontend/app/components/ManageCoverageModal.js
+++ b/frontend/app/components/ManageCoverageModal.js
@@ -92,7 +92,21 @@ export default function ManageCoverageModal({
         const pm = await getPoolManagerWithSigner(depInfo.poolManager)
 
         const dec = await getUnderlyingAssetDecimals(depInfo.capitalPool)
-        const depositBn = ethers.utils.parseUnits(extendCost.toFixed(dec), dec)
+
+        const extraPremium =
+          actionType === "amount" || actionType === "both"
+            ?
+              ((Number.parseFloat(increaseAmount) || 0) *
+                (Number(premium) / 100) *
+                (actionType === "both" ? extendWeeks * 7 : 365)) /
+              365
+            : 0
+
+        const totalCost =
+          (actionType === "duration" || actionType === "both" ? extendCost : 0) +
+          extraPremium
+
+        const depositBn = ethers.utils.parseUnits(totalCost.toFixed(dec), dec)
 
         const assetAddr = await getUnderlyingAssetAddress(depInfo.capitalPool)
         const token = await getERC20WithSigner(assetAddr)


### PR DESCRIPTION
## Summary
- support complex premium extension logic in ManageCoverageModal so the My Active Coverages page can interact with contracts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685950dc7e54832e91a9b44e76ac16e7