### PR TITLE
Add cancellation for withdrawal requests

### DIFF
--- a/contracts/test/MockCapitalPool.sol
+++ b/contracts/test/MockCapitalPool.sol
@@ -155,4 +155,9 @@ contract MockCapitalPool is Ownable {
         (bool ok,) = rm.call(abi.encodeWithSignature("onWithdrawalRequested(address,uint256)", u, amt));
         require(ok, "call failed");
     }
+
+    function triggerOnWithdrawalCancelled(address rm, address u, uint256 amt) external {
+        (bool ok,) = rm.call(abi.encodeWithSignature("onWithdrawalCancelled(address,uint256)", u, amt));
+        require(ok, "call failed");
+    }
 }

--- a/test/CapitalPool.test.js
+++ b/test/CapitalPool.test.js
@@ -252,6 +252,21 @@ describe("CapitalPool", function () {
           .to.be.revertedWithCustomError(capitalPool, "InvalidAmount");
       });
 
+      it("Should cancel a withdrawal request", async () => {
+        const account = await capitalPool.getUnderwriterAccount(user1.address);
+        const sharesToWithdraw = account.masterShares / 2n;
+        await capitalPool.connect(user1).requestWithdrawal(sharesToWithdraw);
+        await expect(capitalPool.connect(user1).cancelWithdrawalRequest())
+          .to.emit(capitalPool, "WithdrawalRequestCancelled");
+        const updated = await capitalPool.getUnderwriterAccount(user1.address);
+        expect(updated.withdrawalRequestShares).to.equal(0);
+      });
+
+      it("cancelWithdrawalRequest reverts when no request", async () => {
+        await expect(capitalPool.connect(user1).cancelWithdrawalRequest())
+          .to.be.revertedWithCustomError(capitalPool, "NoWithdrawalRequest");
+      });
+
       it("Should revert if RiskManager notification fails during executeWithdrawal", async () => {
         const sharesToBurn = (await capitalPool.getUnderwriterAccount(user1.address)).masterShares;
         await capitalPool.connect(user1).requestWithdrawal(sharesToBurn);

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -499,6 +499,22 @@ const MAX_ALLOCATIONS = 5;
                 expect(pool2.capitalPendingWithdrawal).to.equal(amount);
             });
 
+            it("onWithdrawalCancelled should unmark pending withdrawal", async function () {
+                const amount = ethers.parseUnits("500", 6);
+                await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, amount);
+                await mockPoolRegistry.setPoolCount(2);
+                await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
+                await riskManager.connect(underwriter1).allocateCapital([POOL_ID_1, POOL_ID_2]);
+
+                await mockCapitalPool.triggerOnWithdrawalRequested(riskManager.target, underwriter1.address, amount);
+                await mockCapitalPool.triggerOnWithdrawalCancelled(riskManager.target, underwriter1.address, amount);
+
+                const pool1 = await mockPoolRegistry.pools(POOL_ID_1);
+                const pool2 = await mockPoolRegistry.pools(POOL_ID_2);
+                expect(pool1.capitalPendingWithdrawal).to.equal(0);
+                expect(pool2.capitalPendingWithdrawal).to.equal(0);
+            });
+
             it("onCapitalWithdrawn should handle full withdrawal", async function () {
                 const amount = ethers.parseUnits("1000", 6);
                 await mockCapitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter1.address, amount);


### PR DESCRIPTION
## Summary
- allow underwriters to cancel withdrawal requests
- update RiskManager to handle cancellations
- expose new helper in `MockCapitalPool`
- test withdrawal cancellation scenarios

## Testing
- `npx hardhat test test/CapitalPool.test.js test/RiskManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68599a523630832eb0ad556de676739a