### PR TITLE
Show maximum withdrawal amount

### DIFF
--- a/frontend/app/components/UnderwritingWithdrawalModal.js
+++ b/frontend/app/components/UnderwritingWithdrawalModal.js
@@ -10,6 +10,7 @@ export default function UnderwritingWithdrawalModal({
   onRequestWithdrawal,
   isSubmitting = false,
   position,
+  maxWithdrawAmount,
   displayCurrency = "USD",
 }) {
   const [withdrawalType, setWithdrawalType] = useState("partial")
@@ -84,6 +85,12 @@ export default function UnderwritingWithdrawalModal({
             </div>
           </div>
         </div>
+
+        {typeof maxWithdrawAmount === "number" && (
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+            Maximum withdrawable now: {maxWithdrawAmount.toFixed(2)} USDC
+          </p>
+        )}
 
         {/* Withdrawal Type Selection */}
         <div className="space-y-3">


### PR DESCRIPTION
## Summary
- display maximum withdrawable capital in underwriting withdrawal modal
- compute max utilization across pools and pass max amount to modal

## Testing
- `npm test --silent` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68599ac270a0832ea5960ac472d16b00