### PR TITLE
Connect Cat pool withdraw request

### DIFF
--- a/frontend/app/components/CatPoolDeposits.js
+++ b/frontend/app/components/CatPoolDeposits.js
@@ -8,7 +8,12 @@ import useCatPoolRewards from "../../hooks/useCatPoolRewards"
 import Image from "next/image"
 import { TrendingUp, Gift, ExternalLink, Clock, X } from "lucide-react"
 import { getTokenName, getTokenLogo } from "../config/tokenNameMap"
-import { getCatPoolWithSigner, getUsdcAddress, getUsdcDecimals } from "../../lib/catPool"
+import {
+  getCatPoolWithSigner,
+  getUsdcAddress,
+  getUsdcDecimals,
+  getCatShareDecimals,
+} from "../../lib/catPool"
 import ClaimRewardsModal from "./ClaimRewardsModal"
 import RequestWithdrawalModal from "./RequestWithdrawalModal"
 import Link from "next/link"
@@ -72,11 +77,16 @@ export default function CatPoolDeposits({ displayCurrency, refreshTrigger }) {
   const handleRequestWithdrawal = async (withdrawalData) => {
     setIsRequestingWithdrawal(true)
     try {
-      // TODO: Implement actual withdrawal request logic
-      console.log("Requesting withdrawal:", withdrawalData)
-      await new Promise((resolve) => setTimeout(resolve, 2000)) // Simulate transaction
+      const cp = await getCatPoolWithSigner()
+      const dec = await getCatShareDecimals()
+      const sharesBn = ethers.utils.parseUnits(
+        withdrawalData.amount.toString(),
+        dec,
+      )
+      const tx = await cp.requestWithdrawal(sharesBn)
+      setTxHash(tx.hash)
+      await tx.wait()
 
-      // Set pending withdrawal
       setPendingWithdrawal({
         amount: withdrawalData.amount,
         value: withdrawalData.value,


### PR DESCRIPTION
## Summary
- connect CatPool withdrawal request modal to `requestWithdrawal` contract call

## Testing
- `npm test` *(fails: incorrect number of arguments to constructor)*
- `npm --prefix frontend test` *(fails: cannot find module vitest.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_6859a012d5e4832e8690f24fc7f6b445