### PR TITLE
Improve LossDistributor integration tests

### DIFF
--- a/test/LossDistributor.integration.test.js
+++ b/test/LossDistributor.integration.test.js
@@ -74,7 +74,7 @@ async function deployFixture() {
   const COVERAGE = ethers.parseUnits("50000", 6);
   await policyNFT.mock_setPolicy(POLICY_ID, claimant.address, POOL_ID, COVERAGE, 0, 0, 0, 0);
   await policyNFT.setRiskManagerAddress(riskManager.target);
-  await protocolToken.connect(claimant).approve(riskManager.target, COVERAGE);
+  await protocolToken.connect(claimant).approve(riskManager.target, ethers.MaxUint256);
 
   return {
     owner,
@@ -146,5 +146,125 @@ describe("LossDistributor Integration", function () {
     expect(await capitalPool.last_applyLosses_underwriter()).to.equal(underwriter.address);
     expect(await capitalPool.last_applyLosses_principalLossAmount()).to.equal(COVERAGE);
     expect(await riskManager.underwriterTotalPledge(underwriter.address)).to.equal(0n);
+  });
+
+  it("accumulates loss for multiple claims", async function () {
+    const {
+      riskManager,
+      lossDistributor,
+      protocolToken,
+      claimant,
+      nonParty,
+      POOL_ID,
+      POLICY_ID,
+      COVERAGE,
+      TOTAL_PLEDGE,
+      policyNFT,
+    } = await loadFixture(deployFixture);
+
+    await riskManager.connect(nonParty).processClaim(POLICY_ID);
+    const POLICY_ID_2 = 2;
+    const COVERAGE_2 = ethers.parseUnits("20000", 6);
+    await policyNFT.mock_setPolicy(POLICY_ID_2, claimant.address, POOL_ID, COVERAGE_2, 0, 0, 0, 0);
+    await protocolToken.connect(claimant).approve(riskManager.target, ethers.MaxUint256);
+    await riskManager.connect(nonParty).processClaim(POLICY_ID_2);
+
+    const expected = ((COVERAGE + COVERAGE_2) * PRECISION) / TOTAL_PLEDGE;
+    expect(await lossDistributor.poolLossTrackers(POOL_ID)).to.equal(expected);
+  });
+
+  it("realizes proportional losses on partial withdrawal", async function () {
+    const {
+      riskManager,
+      lossDistributor,
+      capitalPool,
+      underwriter,
+      nonParty,
+      POOL_ID,
+      POLICY_ID,
+      COVERAGE,
+      TOTAL_PLEDGE,
+    } = await loadFixture(deployFixture);
+
+    await riskManager.connect(nonParty).processClaim(POLICY_ID);
+
+    const PARTIAL = TOTAL_PLEDGE / 2n;
+    await capitalPool.triggerOnCapitalWithdrawn(
+      riskManager.target,
+      underwriter.address,
+      PARTIAL,
+      false
+    );
+
+    expect(await capitalPool.applyLossesCallCount()).to.equal(1);
+    expect(await capitalPool.last_applyLosses_principalLossAmount()).to.equal(COVERAGE);
+    expect(await riskManager.underwriterTotalPledge(underwriter.address)).to.equal(TOTAL_PLEDGE - COVERAGE - PARTIAL);
+    expect(await riskManager.underwriterPoolPledge(underwriter.address, POOL_ID)).to.equal(TOTAL_PLEDGE - COVERAGE - PARTIAL);
+    expect(await riskManager.isAllocatedToPool(underwriter.address, POOL_ID)).to.equal(false);
+  });
+
+  async function deployTwoPoolFixture() {
+    const base = await deployFixture();
+    const {
+      owner,
+      committee,
+      underwriter,
+      claimant,
+      adapter,
+      poolRegistry,
+      riskManager,
+      policyNFT,
+      protocolToken,
+    } = base;
+
+    const SECOND_POOL_ID = 1;
+    await poolRegistry.setPoolCount(2);
+    await poolRegistry.connect(owner).setPoolData(
+      SECOND_POOL_ID,
+      protocolToken.target,
+      0,
+      0,
+      0,
+      false,
+      committee.address,
+      500
+    );
+    await riskManager.connect(underwriter).allocateCapital([SECOND_POOL_ID]);
+
+    const POLICY_ID_2 = 2;
+    const COVERAGE_2 = ethers.parseUnits("30000", 6);
+    await policyNFT.mock_setPolicy(POLICY_ID_2, claimant.address, SECOND_POOL_ID, COVERAGE_2, 0, 0, 0, 0);
+    await protocolToken.connect(claimant).approve(riskManager.target, ethers.MaxUint256);
+
+    return {
+      ...base,
+      SECOND_POOL_ID,
+      POLICY_ID_2,
+      COVERAGE_2,
+    };
+  }
+
+  it("tracks losses independently per pool", async function () {
+    const {
+      riskManager,
+      lossDistributor,
+      nonParty,
+      POOL_ID,
+      POLICY_ID,
+      COVERAGE,
+      TOTAL_PLEDGE,
+      SECOND_POOL_ID,
+      POLICY_ID_2,
+      COVERAGE_2,
+    } = await loadFixture(deployTwoPoolFixture);
+
+    await riskManager.connect(nonParty).processClaim(POLICY_ID);
+    await riskManager.connect(nonParty).processClaim(POLICY_ID_2);
+
+    const expected1 = (COVERAGE * PRECISION) / TOTAL_PLEDGE;
+    const expected2 = (COVERAGE_2 * PRECISION) / TOTAL_PLEDGE;
+
+    expect(await lossDistributor.poolLossTrackers(POOL_ID)).to.equal(expected1);
+    expect(await lossDistributor.poolLossTrackers(SECOND_POOL_ID)).to.equal(expected2);
   });
 });


### PR DESCRIPTION
## Summary
- expand `LossDistributor.integration.test.js` with scenarios for multiple claims, partial withdrawals and multiple pools
- approve unlimited tokens in fixture to allow multiple claims

## Testing
- `npx hardhat test test/LossDistributor.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685a5cc03660832e83fa2823887ec78e