### PR TITLE
Add more staking integration tests

### DIFF
--- a/test/integration/Staking.integration.test.js
+++ b/test/integration/Staking.integration.test.js
@@ -88,4 +88,84 @@ describe("StakingContract Integration", function () {
       .withArgs(staker.address, STAKE);
     expect(await staking.lastVotedProposal(staker.address)).to.equal(0);
   });
+
+  async function deployLongVotingFixture() {
+    const [owner, riskManager, staker] = await ethers.getSigners();
+
+    const ERC20 = await ethers.getContractFactory("MockERC20");
+    const token = await ERC20.deploy("Governance", "GOV", 18);
+
+    const Staking = await ethers.getContractFactory("StakingContract");
+    const staking = await Staking.deploy(token.target, owner.address);
+
+    const RiskManager = await ethers.getContractFactory("MockCommitteeRiskManager");
+    const rm = await RiskManager.deploy();
+
+    const LONG_VOTING_PERIOD = UNSTAKE_LOCK_PERIOD * 2;
+    const Committee = await ethers.getContractFactory("Committee");
+    const committee = await Committee.deploy(
+      rm.target,
+      staking.target,
+      LONG_VOTING_PERIOD,
+      CHALLENGE_PERIOD,
+      QUORUM_BPS,
+      SLASH_BPS
+    );
+
+    await staking.setCommitteeAddress(committee.target);
+
+    await token.mint(staker.address, ethers.parseEther("3000"));
+    await token.connect(staker).approve(staking.target, ethers.MaxUint256);
+    await token.connect(staker).approve(committee.target, ethers.MaxUint256);
+
+    return { owner, staker, token, staking, committee, LONG_VOTING_PERIOD };
+  }
+
+  it("updates committee vote weight when unstaking mid-vote", async function () {
+    const { staker, staking, committee } = await loadFixture(deployLongVotingFixture);
+
+    await staking.connect(staker).stake(STAKE);
+    await committee.connect(staker).createProposal(1, 0, 0);
+    await committee.connect(staker).vote(1, 2);
+
+    const proposalBefore = await committee.proposals(1);
+    expect(proposalBefore.forVotes).to.equal(STAKE);
+
+    await time.increase(UNSTAKE_LOCK_PERIOD + 1);
+    await staking.connect(staker).unstake(STAKE / 2n);
+
+    const proposalAfter = await committee.proposals(1);
+    expect(proposalAfter.forVotes).to.equal(STAKE / 2n);
+    expect(await staking.stakedBalance(staker.address)).to.equal(STAKE / 2n);
+  });
+
+  it("allows the committee to slash stakers", async function () {
+    const { staker, staking, committee, token } = await loadFixture(deployFixture);
+
+    await staking.connect(staker).stake(STAKE);
+
+    await ethers.provider.send("hardhat_impersonateAccount", [committee.target]);
+    const committeeSigner = await ethers.getSigner(committee.target);
+    await ethers.provider.send("hardhat_setBalance", [committee.target, "0x1000000000000000000"]);
+
+    const slashAmount = ethers.parseEther("40");
+    const balBefore = await token.balanceOf(committee.target);
+
+    await staking.connect(committeeSigner).slash(staker.address, slashAmount);
+
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [committee.target]);
+
+    expect(await staking.stakedBalance(staker.address)).to.equal(STAKE - slashAmount);
+    expect(await token.balanceOf(committee.target)).to.equal(balBefore + slashAmount);
+  });
+
+  it("reverts if a non-committee tries to slash", async function () {
+    const { staker, staking, owner } = await loadFixture(deployFixture);
+
+    await staking.connect(staker).stake(STAKE);
+    await expect(staking.connect(owner).slash(staker.address, 1)).to.be.revertedWithCustomError(
+      staking,
+      "NotCommittee"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- expand integration test coverage for StakingContract
- ensure vote weight updates when unstaking mid-vote
- cover committee slashing behaviour and reverts

## Testing
- `npx hardhat test test/integration/Staking.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685a633051e4832eaa39a362ebafda2b