### PR TITLE
Expand CapitalPool integration coverage

### DIFF
--- a/contracts/test/MockRiskManagerFull.sol
+++ b/contracts/test/MockRiskManagerFull.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockRiskManagerFull {
+    bool public rejectRequest;
+    bool public revertOnDeposit;
+    bool public revertOnCancel;
+
+    event CapitalDeposited(address indexed underwriter, uint256 amount);
+    event WithdrawalRequested(address indexed underwriter, uint256 amount);
+    event WithdrawalCancelled(address indexed underwriter, uint256 amount);
+    event CapitalWithdrawn(address indexed underwriter, uint256 amount, bool full);
+
+    function setRejectRequest(bool _reject) external {
+        rejectRequest = _reject;
+    }
+
+    function setRevertOnDeposit(bool _revert) external {
+        revertOnDeposit = _revert;
+    }
+
+    function setRevertOnCancel(bool _revert) external {
+        revertOnCancel = _revert;
+    }
+
+    function onCapitalDeposited(address _u, uint256 _amount) external {
+        if (revertOnDeposit) revert("MockRM: deposit revert");
+        emit CapitalDeposited(_u, _amount);
+    }
+
+    function onWithdrawalRequested(address _u, uint256 _amount) external {
+        if (rejectRequest) revert("MockRM: reject request");
+        emit WithdrawalRequested(_u, _amount);
+    }
+
+    function onWithdrawalCancelled(address _u, uint256 _amount) external {
+        if (revertOnCancel) revert("MockRM: cancel revert");
+        emit WithdrawalCancelled(_u, _amount);
+    }
+
+    function onCapitalWithdrawn(address _u, uint256 _amount, bool _full) external {
+        emit CapitalWithdrawn(_u, _amount, _full);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MockRiskManagerFull` contract for more extensive integration hooks
- expand CapitalPool hardhat integration tests covering deposit failure and cancellation flows

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_685a66521014832eb8b1f2c87b4fa1ee