### PR TITLE
Fix PoolRegistry integration test to use real contract

### DIFF
--- a/test/integration/PoolRegistry.integration.test.js
+++ b/test/integration/PoolRegistry.integration.test.js
@@ -1,12 +1,13 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-// Simple fixture to deploy PoolRegistry and a mock token
+// Simple fixture to deploy PoolRegistry and a real ERC20 token
 async function deployFixture() {
   const [owner, riskManager, other] = await ethers.getSigners();
 
-  const MockERC20 = await ethers.getContractFactory("MockERC20");
-  const token = await MockERC20.deploy("Mock Token", "MTK", 18);
+  // Use the actual CatShare token contract instead of a mock
+  const CatShare = await ethers.getContractFactory("CatShare");
+  const token = await CatShare.deploy();
   await token.waitForDeployment();
 
   const PoolRegistry = await ethers.getContractFactory("PoolRegistry");


### PR DESCRIPTION
## Summary
- update PoolRegistry integration test to deploy `CatShare` instead of a mock token

## Testing
- `npx hardhat test test/integration/PoolRegistry.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685a697088b0832e8a0749df97a15a0b