### PR TITLE
Improve RewardDistributor integration tests

### DIFF
--- a/test/integration/RewardDistributor.integration.test.js
+++ b/test/integration/RewardDistributor.integration.test.js
@@ -1,47 +1,49 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
-const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { loadFixture, time } = require("@nomicfoundation/hardhat-network-helpers");
 
 const POOL_ID = 0;
 const PLEDGE_AMOUNT = ethers.parseUnits("1000", 6);
 const REWARD_AMOUNT = ethers.parseUnits("100", 6);
 
 async function deployFixture() {
-  const [owner, committee, underwriter, adapter] = await ethers.getSigners();
+  const [owner, committee, underwriter] = await ethers.getSigners();
 
+  // --- Deploy tokens and adapter ---
   const MockERC20 = await ethers.getContractFactory("MockERC20");
   const usdc = await MockERC20.deploy("USD Coin", "USDC", 6);
 
-  const MockPoolRegistry = await ethers.getContractFactory("MockPoolRegistry");
-  const poolRegistry = await MockPoolRegistry.deploy();
-  await poolRegistry.setPoolCount(1);
-  await poolRegistry.connect(owner).setPoolData(
-    POOL_ID,
-    usdc.target,
-    0,
-    0,
-    0,
-    false,
-    committee.address,
-    0
-  );
+  const MockYieldAdapter = await ethers.getContractFactory("MockYieldAdapter");
+  const adapter = await MockYieldAdapter.deploy(usdc.target, ethers.ZeroAddress, owner.address);
 
-  const MockCapitalPool = await ethers.getContractFactory("MockCapitalPool");
-  const capitalPool = await MockCapitalPool.deploy(owner.address, usdc.target);
+  // --- Deploy core protocol contracts ---
+  const CatShare = await ethers.getContractFactory("CatShare");
+  const catShare = await CatShare.deploy();
 
-  const MockPolicyNFT = await ethers.getContractFactory("MockPolicyNFT");
-  const policyNFT = await MockPolicyNFT.deploy(owner.address);
-  await policyNFT.setRiskManagerAddress(owner.address);
+  const CapitalPool = await ethers.getContractFactory("CapitalPool");
+  const capitalPool = await CapitalPool.deploy(owner.address, usdc.target);
+  await capitalPool.setBaseYieldAdapter(1, adapter.target);
 
-  const MockPolicyManager = await ethers.getContractFactory("MockPolicyManager");
-  const policyManager = await MockPolicyManager.deploy();
-  await policyManager.setPolicyNFT(policyNFT.target);
+  const CatPool = await ethers.getContractFactory("CatInsurancePool");
+  const catPool = await CatPool.deploy(usdc.target, catShare.target, adapter.target, owner.address);
+  await catShare.transferOwnership(catPool.target);
+  await catPool.initialize();
+  await adapter.setDepositor(capitalPool.target);
 
-  const MockCatPool = await ethers.getContractFactory("MockCatInsurancePool");
-  const catPool = await MockCatPool.deploy(owner.address);
+  const PolicyNFT = await ethers.getContractFactory("PolicyNFT");
+  const policyNFT = await PolicyNFT.deploy(ethers.ZeroAddress, owner.address);
+
+  const PolicyManager = await ethers.getContractFactory("PolicyManager");
+  const policyManager = await PolicyManager.deploy(policyNFT.target, owner.address);
+  await policyNFT.setPolicyManagerAddress(policyManager.target);
 
   const RiskManager = await ethers.getContractFactory("RiskManager");
   const riskManager = await RiskManager.deploy(owner.address);
+
+  await capitalPool.setRiskManager(riskManager.target);
+
+  const PoolRegistry = await ethers.getContractFactory("PoolRegistry");
+  const poolRegistry = await PoolRegistry.deploy(owner.address, riskManager.target);
 
   const RewardDistributor = await ethers.getContractFactory("RewardDistributor");
   const rewardDistributor = await RewardDistributor.deploy(riskManager.target);
@@ -50,6 +52,7 @@ async function deployFixture() {
   const LossDistributor = await ethers.getContractFactory("LossDistributor");
   const lossDistributor = await LossDistributor.deploy(riskManager.target);
 
+  // Configure protocol relationships
   await riskManager.setAddresses(
     capitalPool.target,
     poolRegistry.target,
@@ -60,13 +63,27 @@ async function deployFixture() {
   );
   await riskManager.setCommittee(committee.address);
 
-  // initial deposit and allocation
-  await capitalPool.triggerOnCapitalDeposited(
-    riskManager.target,
-    underwriter.address,
-    PLEDGE_AMOUNT
+  await policyManager.setAddresses(
+    poolRegistry.target,
+    capitalPool.target,
+    catPool.target,
+    rewardDistributor.target,
+    riskManager.target
   );
-  await capitalPool.setUnderwriterAdapterAddress(underwriter.address, adapter.address);
+
+  await catPool.setRiskManagerAddress(riskManager.target);
+  await catPool.setPolicyManagerAddress(policyManager.target);
+  await catPool.setCapitalPoolAddress(capitalPool.target);
+  await catPool.setRewardDistributor(rewardDistributor.target);
+
+  // Create a pool
+  const rate = { base: 100, slope1: 0, slope2: 0, kink: 8000 };
+  await riskManager.addProtocolRiskPool(usdc.target, rate, 0);
+
+  // Initial deposit & allocation
+  await usdc.mint(underwriter.address, PLEDGE_AMOUNT);
+  await usdc.connect(underwriter).approve(capitalPool.target, PLEDGE_AMOUNT);
+  await capitalPool.connect(underwriter).deposit(PLEDGE_AMOUNT, 1);
   await riskManager.connect(underwriter).allocateCapital([POOL_ID]);
 
   // fund distributor
@@ -85,6 +102,7 @@ async function deployFixture() {
     catPool,
     riskManager,
     rewardDistributor,
+    adapterAddress: adapter.target,
   };
 }
 
@@ -120,7 +138,7 @@ describe("RewardDistributor Integration", function () {
       capitalPool,
       usdc,
       underwriter,
-      adapter,
+      adapterAddress,
     } = await loadFixture(deployFixture);
 
     let [, totalPledged] = await poolRegistry.getPoolData(POOL_ID);
@@ -130,17 +148,12 @@ describe("RewardDistributor Integration", function () {
     await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
 
     const extra = ethers.parseUnits("500", 6);
-    await capitalPool.triggerOnCapitalDeposited(riskManager.target, underwriter.address, extra);
-    await poolRegistry.connect(owner).setPoolData(
-      POOL_ID,
-      usdc.target,
-      PLEDGE_AMOUNT + extra,
-      0,
-      0,
-      false,
-      owner.address,
-      0
-    );
+    await usdc.mint(underwriter.address, extra);
+    await usdc.connect(underwriter).approve(capitalPool.target, extra);
+    await capitalPool.connect(underwriter).deposit(extra, 1);
+    const rm2 = await impersonate(riskManager.target);
+    await poolRegistry.connect(rm2).updateCapitalAllocation(POOL_ID, adapterAddress, extra, true);
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [riskManager.target]);
 
     [, totalPledged] = await poolRegistry.getPoolData(POOL_ID);
     rm = await impersonate(riskManager.target);
@@ -164,6 +177,7 @@ describe("RewardDistributor Integration", function () {
       capitalPool,
       usdc,
       underwriter,
+      adapterAddress,
     } = await loadFixture(deployFixture);
 
     let [, totalPledged] = await poolRegistry.getPoolData(POOL_ID);
@@ -177,22 +191,14 @@ describe("RewardDistributor Integration", function () {
     await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
 
     const withdraw = ethers.parseUnits("400", 6);
-    await capitalPool.triggerOnCapitalWithdrawn(
-      riskManager.target,
-      underwriter.address,
-      withdraw,
-      false
-    );
-    await poolRegistry.connect(owner).setPoolData(
-      POOL_ID,
-      usdc.target,
-      PLEDGE_AMOUNT - withdraw,
-      0,
-      0,
-      false,
-      owner.address,
-      0
-    );
+    const cpSigner = await impersonate(capitalPool.target);
+    await riskManager
+      .connect(cpSigner)
+      .onCapitalWithdrawn(underwriter.address, withdraw, false);
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [capitalPool.target]);
+    const rm2 = await impersonate(riskManager.target);
+    await poolRegistry.connect(rm2).updateCapitalAllocation(POOL_ID, adapterAddress, withdraw, false);
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [riskManager.target]);
 
     [, totalPledged] = await poolRegistry.getPoolData(POOL_ID);
     rm = await impersonate(riskManager.target);


### PR DESCRIPTION
## Summary
- refactor RewardDistributor integration tests
- deploy real protocol contracts instead of mocks
- wire together real RiskManager, PoolRegistry and CapitalPool
- ensure reward distribution scenarios work with real contracts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a697ed674832ea5b4ac0dbc5dbc0c