### PR TITLE
Improve PolicyNFT integration test

### DIFF
--- a/test/integration/PolicyNFT.integration.test.js
+++ b/test/integration/PolicyNFT.integration.test.js
@@ -6,13 +6,13 @@ const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 async function deployFixture() {
   const [owner, user] = await ethers.getSigners();
 
-  const MockERC20 = await ethers.getContractFactory("MockERC20");
-  const usdc = await MockERC20.deploy("USD", "USD", 6);
+  const TestToken = await ethers.getContractFactory("ResetApproveERC20");
+  const usdc = await TestToken.deploy("USD Coin", "USDC", 6);
 
   const CatShare = await ethers.getContractFactory("CatShare");
   const catShare = await CatShare.deploy();
 
-  const YieldAdapter = await ethers.getContractFactory("MockYieldAdapter");
+  const YieldAdapter = await ethers.getContractFactory("SimpleYieldAdapter");
   const adapter = await YieldAdapter.deploy(usdc.target, ethers.ZeroAddress, owner.address);
 
   const CapitalPool = await ethers.getContractFactory("CapitalPool");


### PR DESCRIPTION
## Summary
- use the `ResetApproveERC20` token in PolicyNFT integration tests
- swap mock yield adapter for the real `SimpleYieldAdapter`

## Testing
- `npx hardhat test test/integration/PolicyNFT.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685a6f50fdd4832e823725b2d9142a25