### PR TITLE
Improve LossDistributor integration test coverage

### DIFF
--- a/test/integration/LossDistributor.integration.test.js
+++ b/test/integration/LossDistributor.integration.test.js
@@ -315,6 +315,8 @@ describe("LossDistributor Integration", function () {
     const BIG = ethers.parseUnits("150000", 6);
     const policyBig = await mintPolicy(riskManager, policyNFT, claimant, POOL_ID, BIG);
     await protocolToken.mint(claimant.address, BIG);
+    // Reset approval to satisfy the ResetApproveERC20 requirement
+    await protocolToken.connect(claimant).approve(riskManager.target, 0);
     await protocolToken.connect(claimant).approve(riskManager.target, BIG);
     await riskManager.connect(nonParty).processClaim(policyBig);
 


### PR DESCRIPTION
## Summary
- ensure ResetApproveERC20 approval pattern is respected in LossDistributor integration test

## Testing
- `npx hardhat test test/integration/LossDistributor.integration.test.js` *(fails: CP: Failed to notify RiskManager of withdrawal)*

------
https://chatgpt.com/codex/tasks/task_e_685a75a7bc9c832e925aca451fa61886