### PR TITLE
Fix reserve config fetch on dashboard

### DIFF
--- a/frontend/app/pool/[protocol]/[token]/page.js
+++ b/frontend/app/pool/[protocol]/[token]/page.js
@@ -104,7 +104,10 @@ export default function PoolDetailsPage() {
     [pools, poolId, token],
   )
 
-  const { config: reserveConfig } = useReserveConfig(pool?.deployment)
+  const { config: reserveConfig } = useReserveConfig(
+    pool?.deployment,
+    pool?.id
+  )
 
   console.log(pool, reserveConfig, "reserveConfig")
 

--- a/frontend/hooks/useReserveConfig.js
+++ b/frontend/hooks/useReserveConfig.js
@@ -4,7 +4,7 @@ import { getCapitalPool } from '../lib/capitalPool'
 import { getPolicyManager } from '../lib/policyManager'
 import deployments from '../app/config/deployments'
 
-export default function useReserveConfig(deployment) {
+export default function useReserveConfig(deployment, poolId = 0) {
   const [config, setConfig] = useState(null)
   const [loading, setLoading] = useState(true)
 
@@ -18,7 +18,7 @@ export default function useReserveConfig(deployment) {
         const pm = getPolicyManager(dep.policyManager, dep.name)
         const [cooldown, poolData, notice] = await Promise.all([
           pm.coverCooldownPeriod(),
-          pr.getPoolData(0),
+          pr.getPoolData(poolId),
           cp.underwriterNoticePeriod(),
         ])
         const claimFee = poolData.claimFeeBps ?? poolData[6]
@@ -34,7 +34,7 @@ export default function useReserveConfig(deployment) {
       }
     }
     load()
-  }, [deployment])
+  }, [deployment, poolId])
 
   return { config, loading }
 }


### PR DESCRIPTION
## Summary
- ensure `useReserveConfig` fetches pool-specific config
- pass pool id to `useReserveConfig` hook

## Testing
- `npm test --silent` *(fails: CIP caller not risk manager)*

------
https://chatgpt.com/codex/tasks/task_e_685a7be6771c832e8a047d98bd474b76