### PR TITLE
Show protocol logo in withdraw bond modal

### DIFF
--- a/frontend/app/components/UnstakeBondModal.js
+++ b/frontend/app/components/UnstakeBondModal.js
@@ -5,7 +5,6 @@ import Image from "next/image"
 import { AlertTriangle, Info, Shield, Clock, XCircle, CheckCircle } from "lucide-react"
 import { useAccount } from "wagmi"
 import { getCommitteeWithSigner } from "../../lib/committee"
-import { getTokenLogo } from "../config/tokenNameMap"
 import useUserBonds from "../../hooks/useUserBonds"
 import Modal from "./Modal"
 import { getTxExplorerUrl } from "../utils/explorer"
@@ -121,8 +120,8 @@ export default function UnstakeBondModal({ isOpen, onClose }) {
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
                       <Image
-                        src={bond.logo || "/placeholder.svg"}
-                        alt={bond.symbol}
+                        src={bond.protocolLogo || "/placeholder.svg"}
+                        alt={bond.protocol}
                         width={32}
                         height={32}
                         className="rounded-full"

--- a/frontend/hooks/useUserBonds.js
+++ b/frontend/hooks/useUserBonds.js
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 import { getCommittee } from '../lib/committee'
 import { STAKING_TOKEN_ADDRESS } from '../app/config/deployments'
 import { getTokenDecimals, getTokenSymbol } from '../lib/erc20'
-import { getProtocolName } from '../app/config/tokenNameMap'
+import { getProtocolName, getProtocolLogo } from '../app/config/tokenNameMap'
 
 export default function useUserBonds(address) {
   const [bonds, setBonds] = useState([])
@@ -44,6 +44,7 @@ export default function useUserBonds(address) {
           id: Number(p.id),
           poolId: Number(p.poolId),
           protocol: getProtocolName(Number(p.poolId)),
+          protocolLogo: getProtocolLogo(Number(p.poolId)),
           amount,
           symbol,
           status,


### PR DESCRIPTION
## Summary
- add `protocolLogo` to `useUserBonds`
- use `protocolLogo` image in the Withdraw Bond modal

## Testing
- `npx hardhat test` *(fails: VM exceptions)*
- `npm run test` in `frontend` *(fails: cannot find module vitest.mjs)*
- `npm run test` in `subgraphs/insurance` *(fails: matchstick not found)*
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7d3c77f0832e88cdc26d3121114e