### PR TITLE
Update risk manager claim functions

### DIFF
--- a/foundry/test/RiskManager.t.sol
+++ b/foundry/test/RiskManager.t.sol
@@ -139,8 +139,10 @@ function testDeallocateRealizesLoss() public {
 function testClaimPremiumRewards() public {
     cp.triggerOnCapitalDeposited(address(rm), underwriter, 1000);
     pr.setPoolData(0, token, 0, 0, 0, false, address(0), 0);
+    uint256[] memory ids = new uint256[](1);
+    ids[0] = 0;
     vm.prank(underwriter);
-    rm.claimPremiumRewards(0);
+    rm.claimPremiumRewards(ids);
     assertEq(rd.claimCallCount(), 1);
     assertEq(rd.lastClaimUser(), underwriter);
     assertEq(rd.lastClaimPoolId(), 0);
@@ -150,8 +152,10 @@ function testClaimPremiumRewards() public {
 
 function testClaimDistressedAssets() public {
     pr.setPoolData(0, token, 0, 0, 0, false, address(0), 0);
+    uint256[] memory ids2 = new uint256[](1);
+    ids2[0] = 0;
     vm.prank(underwriter);
-    rm.claimDistressedAssets(0);
+    rm.claimDistressedAssets(ids2);
     assertEq(cat.claimProtocolRewardsCallCount(), 1);
     assertEq(cat.last_claimProtocolToken(), address(token));
 }

--- a/frontend/abi/RiskManager.json
+++ b/frontend/abi/RiskManager.json
@@ -746,9 +746,9 @@
         {
                 "inputs": [
                         {
-                                "internalType": "uint256",
-                                "name": "_poolId",
-                                "type": "uint256"
+                                "internalType": "uint256[]",
+                                "name": "_poolIds",
+                                "type": "uint256[]"
                         },
                         {
                                 "internalType": "uint256",
@@ -764,9 +764,9 @@
         {
                 "inputs": [
                         {
-                                "internalType": "uint256",
-                                "name": "_poolId",
-                                "type": "uint256"
+                                "internalType": "uint256[]",
+                                "name": "_poolIds",
+                                "type": "uint256[]"
                         }
                 ],
                 "name": "deallocateFromPool",
@@ -777,9 +777,9 @@
         {
                 "inputs": [
                         {
-                                "internalType": "uint256",
-                                "name": "_poolId",
-                                "type": "uint256"
+                                "internalType": "uint256[]",
+                                "name": "_poolIds",
+                                "type": "uint256[]"
                         }
                 ],
                 "name": "claimPremiumRewards",
@@ -790,9 +790,9 @@
         {
                 "inputs": [
                         {
-                                "internalType": "uint256",
-                                "name": "_poolId",
-                                "type": "uint256"
+                                "internalType": "uint256[]",
+                                "name": "_poolIds",
+                                "type": "uint256[]"
                         }
                 ],
                 "name": "claimDistressedAssets",

--- a/frontend/app/components/UnderwritingPositions.js
+++ b/frontend/app/components/UnderwritingPositions.js
@@ -235,10 +235,10 @@ export default function UnderwritingPositions({ displayCurrency }) {
       const dep = getDeployment(position.deployment)
       const rm = await getRiskManagerWithSigner(dep.riskManager)
       if (typeof rm.claimPremiumRewards === "function") {
-        await (await rm.claimPremiumRewards(position.poolId)).wait()
+        await (await rm.claimPremiumRewards([position.poolId])).wait()
       }
       if (typeof rm.claimDistressedAssets === "function") {
-        await (await rm.claimDistressedAssets(position.poolId)).wait()
+        await (await rm.claimDistressedAssets([position.poolId])).wait()
       }
     } catch (err) {
       console.error("Failed to claim rewards", err)
@@ -258,13 +258,11 @@ export default function UnderwritingPositions({ displayCurrency }) {
       for (const [depName, ids] of Object.entries(grouped)) {
         const dep = getDeployment(depName)
         const rm = await getRiskManagerWithSigner(dep.riskManager)
-        for (const id of ids) {
-          if (typeof rm.claimPremiumRewards === "function") {
-            await (await rm.claimPremiumRewards(id)).wait()
-          }
-          if (typeof rm.claimDistressedAssets === "function") {
-            await (await rm.claimDistressedAssets(id)).wait()
-          }
+        if (typeof rm.claimPremiumRewards === "function") {
+          await (await rm.claimPremiumRewards(ids)).wait()
+        }
+        if (typeof rm.claimDistressedAssets === "function") {
+          await (await rm.claimDistressedAssets(ids)).wait()
         }
       }
     } catch (err) {
@@ -280,7 +278,7 @@ export default function UnderwritingPositions({ displayCurrency }) {
       const dep = getDeployment(position.deployment)
       const rm = await getRiskManagerWithSigner(dep.riskManager)
       if (typeof rm.claimDistressedAssets === "function") {
-        await (await rm.claimDistressedAssets(position.poolId)).wait()
+        await (await rm.claimDistressedAssets([position.poolId])).wait()
       }
     } catch (err) {
       console.error("Failed to claim distressed assets", err)
@@ -302,10 +300,8 @@ export default function UnderwritingPositions({ displayCurrency }) {
       for (const [depName, ids] of Object.entries(grouped)) {
         const dep = getDeployment(depName)
         const rm = await getRiskManagerWithSigner(dep.riskManager)
-        for (const id of ids) {
-          if (typeof rm.claimDistressedAssets === "function") {
-            await (await rm.claimDistressedAssets(id)).wait()
-          }
+        if (typeof rm.claimDistressedAssets === "function") {
+          await (await rm.claimDistressedAssets(ids)).wait()
         }
       }
     } catch (err) {

--- a/test/RiskManager.test.js
+++ b/test/RiskManager.test.js
@@ -651,7 +651,7 @@ const MAX_ALLOCATIONS = 5;
                 await mockCapitalPool.setUnderwriterAdapterAddress(underwriter1.address, nonParty.address);
                 await riskManager.connect(underwriter1).allocateCapital([POOL_ID_1]);
 
-                await riskManager.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                await riskManager.connect(underwriter1).claimPremiumRewards([POOL_ID_1]);
                 expect(await mockRewardDistributor.claimCallCount()).to.equal(1);
                 expect(await mockRewardDistributor.lastClaimUser()).to.equal(underwriter1.address);
                 expect(await mockRewardDistributor.lastClaimPledge()).to.equal(amount);
@@ -659,7 +659,7 @@ const MAX_ALLOCATIONS = 5;
 
             it("claimDistressedAssets should call the cat pool", async function () {
                 await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, 0, 0, 0, false, committee.address, 0);
-                await riskManager.connect(nonParty).claimDistressedAssets(POOL_ID_1);
+                await riskManager.connect(nonParty).claimDistressedAssets([POOL_ID_1]);
                 expect(await mockCatPool.claimProtocolRewardsCallCount()).to.equal(1);
                 expect(await mockCatPool.last_claimProtocolToken()).to.equal(mockUsdc.target);
                 expect(await mockCatPool.last_claimUser()).to.equal(nonParty.address);
@@ -706,7 +706,7 @@ const MAX_ALLOCATIONS = 5;
                 await realRM.connect(underwriter1).allocateCapital([POOL_ID_1]);
 
                 await distribute(reward, first);
-                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                await realRM.connect(underwriter1).claimPremiumRewards([POOL_ID_1]);
 
                 await mockCapitalPool.triggerOnCapitalDeposited(realRM.target, underwriter1.address, second);
                 await mockPoolRegistry.connect(owner).setPoolData(POOL_ID_1, mockUsdc.target, first + second, 0, 0, false, committee.address, 0);
@@ -716,7 +716,7 @@ const MAX_ALLOCATIONS = 5;
                 const pledgeNow = await realRM.underwriterPoolPledge(underwriter1.address, POOL_ID_1);
                 const expected = await realRD.pendingRewards(underwriter1.address, POOL_ID_1, mockUsdc.target, pledgeNow);
                 const before = await mockUsdc.balanceOf(underwriter1.address);
-                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                await realRM.connect(underwriter1).claimPremiumRewards([POOL_ID_1]);
                 const after = await mockUsdc.balanceOf(underwriter1.address);
                 expect(after - before).to.equal(expected);
             });
@@ -732,7 +732,7 @@ const MAX_ALLOCATIONS = 5;
                 await realRM.connect(underwriter1).allocateCapital([POOL_ID_1]);
 
                 await distribute(reward, pledge);
-                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                await realRM.connect(underwriter1).claimPremiumRewards([POOL_ID_1]);
 
                 await mockLossDistributor.setPendingLoss(underwriter1.address, POOL_ID_1, 0);
                 await mockCapitalPool.triggerOnCapitalWithdrawn(realRM.target, underwriter1.address, withdraw, false);
@@ -742,7 +742,7 @@ const MAX_ALLOCATIONS = 5;
                 const pledgeNow = await realRM.underwriterPoolPledge(underwriter1.address, POOL_ID_1);
                 const expected = await realRD.pendingRewards(underwriter1.address, POOL_ID_1, mockUsdc.target, pledgeNow);
                 const before = await mockUsdc.balanceOf(underwriter1.address);
-                await realRM.connect(underwriter1).claimPremiumRewards(POOL_ID_1);
+                await realRM.connect(underwriter1).claimPremiumRewards([POOL_ID_1]);
                 const after = await mockUsdc.balanceOf(underwriter1.address);
                 expect(after - before).to.equal(expected);
             });

--- a/test/integration/RewardDistributor.integration.test.js
+++ b/test/integration/RewardDistributor.integration.test.js
@@ -125,7 +125,7 @@ describe("RewardDistributor Integration", function () {
     const pledgeNow = await riskManager.underwriterPoolPledge(underwriter.address, POOL_ID);
     const expected = await rewardDistributor.pendingRewards(underwriter.address, POOL_ID, usdc.target, pledgeNow);
     const before = await usdc.balanceOf(underwriter.address);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
     const after = await usdc.balanceOf(underwriter.address);
     expect(after - before).to.equal(expected);
   });
@@ -146,7 +146,7 @@ describe("RewardDistributor Integration", function () {
     let rm = await impersonate(riskManager.target);
     await rewardDistributor.connect(rm).distribute(POOL_ID, usdc.target, REWARD_AMOUNT, totalPledged);
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [riskManager.target]);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
 
     const extra = ethers.parseUnits("500", 6);
     await usdc.mint(underwriter.address, extra);
@@ -164,7 +164,7 @@ describe("RewardDistributor Integration", function () {
     const pledgeNow = await riskManager.underwriterPoolPledge(underwriter.address, POOL_ID);
     const expected = await rewardDistributor.pendingRewards(underwriter.address, POOL_ID, usdc.target, pledgeNow);
     const before = await usdc.balanceOf(underwriter.address);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
     const after = await usdc.balanceOf(underwriter.address);
     expect(after - before).to.equal(expected);
   });
@@ -189,7 +189,7 @@ describe("RewardDistributor Integration", function () {
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [
       riskManager.target,
     ]);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
 
     const withdraw = ethers.parseUnits("400", 6);
     const cpSigner = await impersonate(capitalPool.target);
@@ -221,7 +221,7 @@ describe("RewardDistributor Integration", function () {
       pledgeNow
     );
     const before = await usdc.balanceOf(underwriter.address);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
     const after = await usdc.balanceOf(underwriter.address);
     expect(after - before).to.equal(expected);
   });
@@ -297,7 +297,7 @@ describe("RewardDistributor Integration", function () {
     const expected = await rewardDistributor.pendingRewards(underwriter.address, POOL_ID, usdc.target, pledge);
     expect(expected).to.equal(REWARD_AMOUNT * 2n);
     const before = await usdc.balanceOf(underwriter.address);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
     const after = await usdc.balanceOf(underwriter.address);
     expect(after - before).to.equal(expected);
   });

--- a/test/integration/RiskManager.integration.test.js
+++ b/test/integration/RiskManager.integration.test.js
@@ -170,7 +170,7 @@ describe("RiskManager Integration", function () {
     await rewardDistributor.connect(rm).distribute(POOL_ID, usdc.target, reward, totalPledged);
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [riskManager.target]);
     const before = await usdc.balanceOf(underwriter.address);
-    await riskManager.connect(underwriter).claimPremiumRewards(POOL_ID);
+    await riskManager.connect(underwriter).claimPremiumRewards([POOL_ID]);
     const after = await usdc.balanceOf(underwriter.address);
     expect(after).to.be.gt(before);
   });
@@ -208,7 +208,7 @@ describe("RiskManager Integration", function () {
     await ethers.provider.send("hardhat_stopImpersonatingAccount", [riskManager.target]);
 
     const before = await usdc.balanceOf(nonParty.address);
-    await riskManager.connect(nonParty).claimDistressedAssets(POOL_ID);
+    await riskManager.connect(nonParty).claimDistressedAssets([POOL_ID]);
     const after = await usdc.balanceOf(nonParty.address);
     expect(after).to.be.gt(before);
   });


### PR DESCRIPTION
## Summary
- add array support to RiskManager claim functions in frontend ABI and JS components
- adjust tests to use new claimPremiumRewards and claimDistressedAssets signatures
- update foundry tests accordingly

## Testing
- `npm run test:RiskManager`
- `npm run test:RewardDistributor`
- `npx hardhat test test/integration/RiskManager.integration.test.js`
- `forge test --match-contract RiskManager -vv` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8253cfc0832ea70c7979a8e6befb