### PR TITLE
Fix BigInt serialization in underwriter API

### DIFF
--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -113,11 +113,11 @@ export async function GET(
 
         details.push({
           deployment: dep.name,
-          totalDepositedAssetPrincipal: account[0],
-          yieldChoice: account[1],
-          masterShares: account[2],
-          withdrawalRequestTimestamp,
-          withdrawalRequestShares,
+          totalDepositedAssetPrincipal: account[0].toString(),
+          yieldChoice: account[1].toString(),
+          masterShares: account[2].toString(),
+          withdrawalRequestTimestamp: withdrawalRequestTimestamp.toString(),
+          withdrawalRequestShares: withdrawalRequestShares.toString(),
           allocatedPoolIds,
           pendingLosses,
         })


### PR DESCRIPTION
## Summary
- handle BigInt values in underwriter details API response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa17b935c832e80e32442f9483b9a