### PR TITLE
Fix API BigInt serialization

### DIFF
--- a/frontend/app/api/policies/[id]/route.ts
+++ b/frontend/app/api/policies/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { policyNft } from '../../../../lib/policyNft'
 import { getPoolRegistry } from '@/lib/poolRegistry'
 import { getPolicyManager } from '@/lib/policyManager'
+import bnToString from '../../../../lib/bnToString'
 import deployments from '../../../config/deployments'
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
@@ -38,9 +39,9 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
       id: Number(id),
       deployment,
       policy: {
-        ...policy,
-        pendingIncrease,
-        increaseActivationTimestamp,
+        ...bnToString(policy),
+        pendingIncrease: bnToString(pendingIncrease),
+        increaseActivationTimestamp: bnToString(increaseActivationTimestamp),
       },
     })
   } catch (err: any) {

--- a/frontend/app/api/policies/user/[address]/route.ts
+++ b/frontend/app/api/policies/user/[address]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { policyNft } from '@/lib/policyNft'
 import { getPoolRegistry } from '@/lib/poolRegistry'
 import { getPolicyManager } from '@/lib/policyManager'
+import bnToString from '../../../../../lib/bnToString'
 import deployments from '../../../../config/deployments'
 
 export async function GET(
@@ -49,9 +50,11 @@ export async function GET(
           policies.push({
             id: Number(i),
             deployment,
-            ...p,
-            pendingIncrease,
-            increaseActivationTimestamp,
+            ...bnToString(p),
+            pendingIncrease: bnToString(pendingIncrease),
+            increaseActivationTimestamp: bnToString(
+              increaseActivationTimestamp,
+            ),
           })
         }
       } catch {

--- a/frontend/app/api/pools/list/route.ts
+++ b/frontend/app/api/pools/list/route.ts
@@ -8,6 +8,7 @@ import {
   getUnderlyingAssetAddress,
   getUnderlyingAssetDecimals,
 } from "../../../../lib/capitalPool";
+import bnToString from "../../../../lib/bnToString";
 import { ethers } from "ethers";
 import deployments from "../../../config/deployments";
 
@@ -27,43 +28,6 @@ const BPS = 10_000n;
  * (e.g. `rateModel`), we keep the named‑key object instead of an index array so
  * callers can reference `rateModel.base` rather than guessing positions.
  */
-function bnToString(value: any): any {
-  // 1️⃣ Native bigint ────────────────────────────
-  if (typeof value === "bigint") return value.toString();
-
-  // 2️⃣ ethers.js BigNumber ─────────────────────
-  if (value && typeof value === "object" && value._isBigNumber) {
-    return value.toString();
-  }
-
-  // 3️⃣ Array (may also have named props) ───────
-  if (Array.isArray(value)) {
-    const hasNamedKeys = Object.keys(value).some((k) => isNaN(Number(k)));
-
-    if (hasNamedKeys) {
-      // Convert to a plain object of the named keys only.
-      return Object.fromEntries(
-        Object.entries(value)
-          .filter(([k]) => isNaN(Number(k)))
-          .map(([k, v]) => [k, bnToString(v)])
-      );
-    }
-
-    // Pure, positional array → recurse element‑wise.
-    return value.map(bnToString);
-  }
-
-  // 4️⃣ Plain object ─────────────────────────────
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .filter(([k]) => isNaN(Number(k))) // drop numeric keys
-        .map(([k, v]) => [k, bnToString(v)])
-    );
-  }
-
-  return value;
-}
 
 /**
  * Pool‑utilisation helper used by the premium‑rate function.

--- a/frontend/lib/bnToString.ts
+++ b/frontend/lib/bnToString.ts
@@ -1,0 +1,33 @@
+export default function bnToString(value: any): any {
+  // 1️⃣ Native bigint
+  if (typeof value === 'bigint') return value.toString();
+
+  // 2️⃣ ethers.js BigNumber (v6 uses BigInt; but keep for compatibility)
+  if (value && typeof value === 'object' && value._isBigNumber) {
+    return value.toString();
+  }
+
+  // 3️⃣ Array (may also have named props)
+  if (Array.isArray(value)) {
+    const hasNamedKeys = Object.keys(value).some((k) => isNaN(Number(k)));
+    if (hasNamedKeys) {
+      return Object.fromEntries(
+        Object.entries(value)
+          .filter(([k]) => isNaN(Number(k)))
+          .map(([k, v]) => [k, bnToString(v)])
+      );
+    }
+    return value.map(bnToString);
+  }
+
+  // 4️⃣ Plain object
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([k]) => isNaN(Number(k)))
+        .map(([k, v]) => [k, bnToString(v)])
+    );
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- add `bnToString` helper to convert `BigInt` and `BigNumber` values
- use helper when returning policies
- reuse helper from pools API

## Testing
- `npm run test` *(fails: Cannot find module 'vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_685ad3815afc832e8c3c0fb69f4236ef