### PR TITLE
Add PolicyNFT fuzz tests

### DIFF
--- a/fuzz/foundry.toml
+++ b/fuzz/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+src = "src"
+test = 'test'
+out = 'out'
+libs = ['../lib', '../node_modules']
+remappings = ["@openzeppelin/=../node_modules/@openzeppelin/", "@chainlink/contracts/=../node_modules/@chainlink/contracts/"]
+solc_version = '0.8.20'
+via_ir = true
+optimizer = true
+optimizer_runs = 1000
+fs_permissions = [{ access = "read", path = "../" }, { access = "read", path = "../contracts" }, { access = "read", path = "../node_modules" }]

--- a/fuzz/src/PolicyNFT.sol
+++ b/fuzz/src/PolicyNFT.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title PolicyNFT
+ * @author Gemini
+ * @notice This contract manages the ownership and state of insurance policies as NFTs.
+ * This version is simplified to work with a PolicyManager that handles pending increase logic externally.
+ */
+contract PolicyNFT is ERC721URIStorage, Ownable {
+    
+    // MODIFIED: The struct is now simpler, only holding the active state.
+    struct Policy {
+        uint256 coverage;       // Currently active liability
+        uint256 poolId;
+        uint256 start;
+        uint256 activation;     // Activation for the initial coverage
+        uint128 premiumDeposit;
+        uint128 lastDrainTime;
+    }
+
+    uint256 public nextId = 1;
+    mapping(uint256 => Policy) public policies;
+    address public policyManagerContract;
+
+    // --- Events ---
+    event PolicyPremiumAccountUpdated(uint256 indexed policyId, uint128 newDeposit, uint128 newDrainTime);
+    event PolicyCoverageIncreased(uint256 indexed policyId, uint256 newTotalCoverage);
+    event PolicyManagerAddressSet(address indexed newPolicyManagerAddress);
+
+
+    modifier onlyPolicyManager() {
+        require(policyManagerContract != address(0), "PolicyNFT: PolicyManager address not set");
+        require(msg.sender == policyManagerContract, "PolicyNFT: Caller is not the authorized PolicyManager");
+        _;
+    }
+
+    constructor(address _initialPolicyManager, address initialOwner) ERC721("Policy", "PCOVER") Ownable(initialOwner) {
+        policyManagerContract = _initialPolicyManager;
+    }
+
+    function setPolicyManagerAddress(address _newPolicyManagerAddress) external onlyOwner {
+        require(_newPolicyManagerAddress != address(0), "PolicyNFT: Address cannot be zero");
+        policyManagerContract = _newPolicyManagerAddress;
+        emit PolicyManagerAddressSet(_newPolicyManagerAddress);
+    }
+
+    /**
+     * @notice Mints a new policy NFT. Only callable by the authorized PolicyManager.
+     */
+    function mint(
+        address to,
+        uint256 pid,
+        uint256 coverage,
+        uint256 activation,
+        uint128 premiumDeposit,
+        uint128 lastDrainTime
+    ) external onlyPolicyManager returns (uint256 id) {
+        id = nextId++;
+        _safeMint(to, id);
+        
+        // MODIFIED: Initialize the simpler struct.
+        policies[id] = Policy({
+            coverage: coverage,
+            poolId: pid,
+            start: block.timestamp,
+            activation: activation,
+            premiumDeposit: premiumDeposit,
+            lastDrainTime: lastDrainTime
+        });
+        return id;
+    }
+
+    /**
+     * @notice Burns a policy NFT. Only callable by the authorized PolicyManager.
+     */
+    function burn(uint256 id) external onlyPolicyManager {
+        _burn(id);
+        delete policies[id];
+    }
+
+    /**
+     * @notice Updates the premium details for a policy.
+     */
+    function updatePremiumAccount(uint256 id, uint128 newDeposit, uint128 newDrainTime) external onlyPolicyManager {
+        // A non-zero 'start' time confirms the policy exists.
+        require(policies[id].start != 0, "PolicyNFT: Policy does not exist or has been burned");
+        
+        Policy storage policy = policies[id];
+        policy.premiumDeposit = newDeposit;
+        policy.lastDrainTime = newDrainTime;
+        emit PolicyPremiumAccountUpdated(id, newDeposit, newDrainTime);
+    }
+    
+    /**
+     * @notice NEW: Finalizes one or more matured increases, adding the total amount to the main coverage.
+     * @dev Called by the PolicyManager after it has processed its queue of pending increases.
+     * @param id The ID of the policy NFT.
+     * @param totalAmountToAdd The sum of all matured coverage increases to be added.
+     */
+    function finalizeIncreases(uint256 id, uint256 totalAmountToAdd) external onlyPolicyManager {
+        require(policies[id].start != 0, "PolicyNFT: Policy does not exist or has been burned");
+        require(totalAmountToAdd > 0, "PolicyNFT: Amount to add must be greater than zero");
+
+        Policy storage policy = policies[id];
+        policy.coverage += totalAmountToAdd;
+        
+        emit PolicyCoverageIncreased(id, policy.coverage);
+    }
+
+    // REMOVED: addPendingIncrease(), finalizeIncrease(), and updateCoverage() are no longer needed.
+    // Their logic is now handled by the PolicyManager and the new finalizeIncreases() function.
+
+    /**
+     * @notice Retrieves the data for a specific policy.
+     */
+    function getPolicy(uint256 id) external view returns (Policy memory) {
+        return policies[id];
+    }
+}

--- a/fuzz/test/PolicyNFTFuzz.t.sol
+++ b/fuzz/test/PolicyNFTFuzz.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {PolicyNFT} from "../src/PolicyNFT.sol";
+
+contract PolicyNFTFuzz is Test {
+    PolicyNFT nft;
+    address owner = address(this);
+    address manager = address(0x1);
+    address user = address(0x2);
+
+    function setUp() public {
+        nft = new PolicyNFT(address(0), owner);
+    }
+
+    function testFuzz_SetPolicyManagerAddress(address newManager) public {
+        vm.assume(newManager != address(0));
+        nft.setPolicyManagerAddress(newManager);
+        assertEq(nft.policyManagerContract(), newManager);
+    }
+
+    function testFuzz_SetPolicyManagerAddressOnlyOwner(address newManager) public {
+        vm.assume(newManager != address(0));
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", user));
+        nft.setPolicyManagerAddress(newManager);
+    }
+
+    function testFuzz_MintStoresPolicy(
+        address to,
+        uint256 pid,
+        uint256 coverage,
+        uint256 activation,
+        uint128 deposit,
+        uint128 drain
+    ) public {
+        vm.assume(to != address(0) && to.code.length == 0);
+        nft.setPolicyManagerAddress(manager);
+        vm.prank(manager);
+        uint256 id = nft.mint(to, pid, coverage, activation, deposit, drain);
+        assertEq(id, 1);
+        PolicyNFT.Policy memory p = nft.getPolicy(1);
+        assertEq(p.coverage, coverage);
+        assertEq(p.poolId, pid);
+        assertEq(p.activation, activation);
+        assertEq(p.premiumDeposit, deposit);
+        assertEq(p.lastDrainTime, drain);
+        assertEq(nft.ownerOf(1), to);
+    }
+
+    function testFuzz_BurnDeletesPolicy(uint256 pid, uint256 coverage) public {
+        nft.setPolicyManagerAddress(manager);
+        vm.prank(manager);
+        nft.mint(user, pid, coverage, 0, 0, 0);
+
+        vm.prank(manager);
+        nft.burn(1);
+        vm.expectRevert();
+        nft.ownerOf(1);
+        PolicyNFT.Policy memory p = nft.getPolicy(1);
+        assertEq(p.coverage, 0);
+        assertEq(p.poolId, 0);
+        assertEq(p.start, 0);
+    }
+
+    function testFuzz_UpdatePremiumAccount(uint128 deposit, uint128 drain) public {
+        nft.setPolicyManagerAddress(manager);
+        vm.prank(manager);
+        nft.mint(user, 1, 1, 0, 0, 0);
+
+        vm.prank(manager);
+        nft.updatePremiumAccount(1, deposit, drain);
+        PolicyNFT.Policy memory p = nft.getPolicy(1);
+        assertEq(p.premiumDeposit, deposit);
+        assertEq(p.lastDrainTime, drain);
+    }
+
+    function testFuzz_FinalizeIncreases(uint256 addAmount) public {
+        nft.setPolicyManagerAddress(manager);
+        vm.prank(manager);
+        nft.mint(user, 1, 100, 0, 0, 0);
+        vm.assume(addAmount > 0 && addAmount <= type(uint256).max - 100);
+        vm.prank(manager);
+        nft.finalizeIncreases(1, addAmount);
+        PolicyNFT.Policy memory p = nft.getPolicy(1);
+        assertEq(p.coverage, 100 + addAmount);
+    }
+
+    function testFuzz_GetPolicyNonexistent(uint256 id) public view {
+        vm.assume(id != 1);
+        PolicyNFT.Policy memory p = nft.getPolicy(id);
+        assertEq(p.coverage, 0);
+        assertEq(p.poolId, 0);
+        assertEq(p.start, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add an isolated Foundry project with fuzz tests for PolicyNFT
- ensure manager address restrictions, mint/burn, premium updates, and coverage increases work across fuzzed inputs

## Testing
- `forge test -vv`

------
https://chatgpt.com/codex/tasks/task_e_685d31f9c5ac832e976274c211f8c108