### PR TITLE
Move logo to sidebar

### DIFF
--- a/frontend/app/components/Navbar.js
+++ b/frontend/app/components/Navbar.js
@@ -26,7 +26,7 @@ export default function Navbar() {
     <nav className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16">
-          <div className="flex items-center">
+          <div className="flex items-center md:hidden">
             <Link href="/" className="flex-shrink-0 flex items-center">
               <div className="flex items-center space-x-3">
                 <div className="relative">

--- a/frontend/app/components/Sidebar.js
+++ b/frontend/app/components/Sidebar.js
@@ -27,6 +27,35 @@ export default function Sidebar() {
   return (
     <div className="hidden md:flex md:w-64 md:flex-col md:fixed md:inset-y-0 pt-16">
       <div className="flex-1 flex flex-col min-h-0 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+        <div className="px-4 pt-5 pb-2">
+          <Link href="/" className="flex items-center space-x-3">
+            <div className="relative">
+              <div className="w-10 h-10 bg-gradient-to-br from-slate-600 to-slate-800 rounded-lg flex items-center justify-center shadow-lg">
+                <svg
+                  className="w-6 h-6 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                  />
+                </svg>
+              </div>
+              <div className="absolute -top-1 -right-1 w-3 h-3 bg-emerald-500 rounded-full border-2 border-white dark:border-gray-800"></div>
+            </div>
+            <div>
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+                Layer<span className="text-slate-600 dark:text-slate-400">Cover</span>
+              </h1>
+              <p className="text-xs text-gray-500 dark:text-gray-400 -mt-1">Insurance Protocol</p>
+            </div>
+          </Link>
+        </div>
         <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
           <nav className="mt-5 flex-1 px-2 space-y-1">
             {navigation.map((item) => {


### PR DESCRIPTION
## Summary
- relocate LayerCover logo from navbar to sidebar
- hide navbar logo on desktop so the sidebar logo appears instead

## Testing
- `npm test` *(fails: Cannot find module `vitest.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_686e716ab64c832e98aea5d6607406a3