### PR TITLE
Add BackstopPool fuzz tests

### DIFF
--- a/contracts/test/MockPolicyNFT.sol
+++ b/contracts/test/MockPolicyNFT.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/IPolicyNFT.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract MockPolicyNFT is IPolicyNFT, Ownable {
+    uint256 public nextPolicyId = 1;
+    mapping(uint256 => IPolicyNFT.Policy) public policies;
+    address public coverPoolAddress;
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function setCoverPoolAddress(address _pool) external {
+        coverPoolAddress = _pool;
+    }
+
+    function mint(
+        address,
+        uint256 poolId,
+        uint256 coverage,
+        uint256 activation,
+        uint128 premiumDeposit,
+        uint128 lastDrainTime
+    ) external override returns (uint256 id) {
+        id = nextPolicyId++;
+        policies[id] = IPolicyNFT.Policy({
+            coverage: coverage,
+            poolId: poolId,
+            start: block.timestamp,
+            activation: activation,
+            premiumDeposit: premiumDeposit,
+            lastDrainTime: lastDrainTime
+        });
+    }
+
+    function finalizeIncreases(uint256 policyId, uint256 amount) external override {
+        policies[policyId].coverage += amount;
+    }
+
+    function burn(uint256 policyId) external override {
+        delete policies[policyId];
+    }
+
+    function ownerOf(uint256) external view override returns (address) {
+        return address(0);
+    }
+
+    function getPolicy(uint256 policyId) external view override returns (Policy memory) {
+        return policies[policyId];
+    }
+
+    function updatePremiumAccount(uint256 policyId, uint128 newDeposit, uint128 newDrainTime) external override {
+        IPolicyNFT.Policy storage pol = policies[policyId];
+        pol.premiumDeposit = newDeposit;
+        pol.lastDrainTime = newDrainTime;
+    }
+
+    function mock_setPolicy(
+        uint256 policyId,
+        address,
+        uint256 poolId,
+        uint256 coverage,
+        uint256 start,
+        uint256 activation,
+        uint128 premiumDeposit,
+        uint128 lastDrainTime
+    ) external {
+        policies[policyId] = IPolicyNFT.Policy({
+            coverage: coverage,
+            poolId: poolId,
+            start: start,
+            activation: activation,
+            premiumDeposit: premiumDeposit,
+            lastDrainTime: lastDrainTime
+        });
+        if (policyId >= nextPolicyId) {
+            nextPolicyId = policyId + 1;
+        }
+    }
+}

--- a/foundry/test/BackstopPool.t.sol
+++ b/foundry/test/BackstopPool.t.sol
@@ -58,6 +58,9 @@ contract BackstopPoolTest is Test {
 
         uint256 shares = share.balanceOf(user);
         vm.prank(user);
+        pool.requestWithdrawal(shares);
+        vm.warp(block.timestamp + pool.NOTICE_PERIOD());
+        vm.prank(user);
         pool.withdrawLiquidity(shares);
 
         // expected withdrawal = shares * totalValue / (totalShares - locked)

--- a/foundry/test/BackstopPoolFuzz.t.sol
+++ b/foundry/test/BackstopPoolFuzz.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {BackstopPool} from "contracts/external/BackstopPool.sol";
+import {CatShare} from "contracts/tokens/CatShare.sol";
+import {MockERC20} from "contracts/test/MockERC20.sol";
+import {MockYieldAdapter} from "contracts/test/MockYieldAdapter.sol";
+import {MockRewardDistributor} from "contracts/test/MockRewardDistributor.sol";
+
+contract BackstopPoolFuzz is Test {
+    BackstopPool pool;
+    CatShare share;
+    MockERC20 usdc;
+    MockYieldAdapter adapter;
+    MockRewardDistributor distributor;
+
+    address user = address(0x1);
+    address user2 = address(0x2);
+    address riskManager = address(0x3);
+    address capitalPool = address(0x4);
+    address policyManager = address(0x5);
+
+    uint256 constant STARTING_BALANCE = 1_000_000e6;
+    uint256 constant INITIAL_SHARES_LOCKED = 1000;
+
+    function setUp() public {
+        usdc = new MockERC20("USD", "USD", 6);
+        share = new CatShare();
+        adapter = new MockYieldAdapter(address(usdc), address(0), address(this));
+        distributor = new MockRewardDistributor();
+
+        usdc.mint(user, STARTING_BALANCE);
+        usdc.mint(user2, STARTING_BALANCE);
+
+        pool = new BackstopPool(usdc, share, adapter, address(this));
+        share.transferOwnership(address(pool));
+        pool.initialize();
+
+        adapter.setDepositor(address(pool));
+
+        pool.setRiskManagerAddress(riskManager);
+        pool.setCapitalPoolAddress(capitalPool);
+        pool.setPolicyManagerAddress(policyManager);
+        pool.setRewardDistributor(address(distributor));
+
+        vm.prank(user);
+        usdc.approve(address(pool), type(uint256).max);
+        vm.prank(user2);
+        usdc.approve(address(pool), type(uint256).max);
+    }
+
+    function testFuzz_depositWithdraw(uint96 amount) public {
+        uint256 min = pool.MIN_USDC_AMOUNT();
+        vm.assume(amount >= min && amount <= STARTING_BALANCE);
+
+        vm.prank(user);
+        pool.depositLiquidity(amount);
+
+        vm.prank(user);
+        pool.requestWithdrawal(amount);
+        vm.warp(block.timestamp + pool.NOTICE_PERIOD());
+        vm.prank(user);
+        pool.withdrawLiquidity(amount);
+
+        assertEq(usdc.balanceOf(user), STARTING_BALANCE);
+        assertEq(share.totalSupply(), INITIAL_SHARES_LOCKED);
+    }
+
+    function testFuzz_flushAndWithdrawFromAdapter(uint96 depositAmount, uint96 yieldGain) public {
+        uint256 min = pool.MIN_USDC_AMOUNT();
+        vm.assume(depositAmount >= min && depositAmount < STARTING_BALANCE / 2);
+        vm.assume(yieldGain <= depositAmount);
+
+        vm.prank(user);
+        pool.depositLiquidity(depositAmount);
+        pool.flushToAdapter(depositAmount);
+
+        usdc.mint(address(adapter), yieldGain);
+        adapter.setTotalValueHeld(depositAmount + yieldGain);
+
+        uint256 sharesToBurn = share.balanceOf(user);
+        vm.prank(user);
+        pool.requestWithdrawal(sharesToBurn);
+        vm.warp(block.timestamp + pool.NOTICE_PERIOD());
+        vm.prank(user);
+        pool.withdrawLiquidity(sharesToBurn);
+
+        assertEq(adapter.totalValueHeld(), 0);
+        assertEq(usdc.balanceOf(user), STARTING_BALANCE + yieldGain);
+    }
+
+    function testFuzz_multipleDeposits(uint96 first, uint96 second) public {
+        uint256 min = pool.MIN_USDC_AMOUNT();
+        vm.assume(first >= min && second >= min);
+        vm.assume(uint256(first) + uint256(second) < STARTING_BALANCE);
+
+        vm.prank(user);
+        pool.depositLiquidity(first);
+        uint256 supplyBefore = share.totalSupply();
+        uint256 valueBefore = pool.liquidUsdc();
+        vm.assume(supplyBefore > INITIAL_SHARES_LOCKED);
+        vm.assume(valueBefore > 0);
+
+        vm.prank(user2);
+        pool.depositLiquidity(second);
+
+        uint256 expected = (second * (supplyBefore - INITIAL_SHARES_LOCKED)) / valueBefore;
+        assertEq(share.balanceOf(user2), expected);
+    }
+
+    function testFuzz_drawFund(uint96 depositAmount, uint96 drawAmount) public {
+        uint256 min = pool.MIN_USDC_AMOUNT();
+        vm.assume(depositAmount >= min && drawAmount > 0);
+        vm.assume(drawAmount <= depositAmount && depositAmount < STARTING_BALANCE);
+
+        vm.prank(user);
+        pool.depositLiquidity(depositAmount);
+
+        vm.prank(riskManager);
+        pool.drawFund(drawAmount);
+
+        assertEq(usdc.balanceOf(capitalPool), drawAmount);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a minimal `MockPolicyNFT` test contract
- add `BackstopPoolFuzz.t.sol` with fuzz tests
- update existing BackstopPool test for new withdrawal logic

## Testing
- `forge build foundry/test/BackstopPoolFuzz.t.sol foundry/test/BackstopPool.t.sol`
- `forge test -vv`

------
https://chatgpt.com/codex/tasks/task_e_6870ef469740832eabbc8fdbf1938c36