### PR TITLE
Improve LossDistributor fuzz test coverage

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,3 +15,6 @@ solc_version = '0.8.20'
 [profile.pool]
 test = 'foundry/test/PoolRegistryFuzz.t.sol'
 
+[profile.lossfuzz]
+test = 'foundry/test/LossDistributorFuzz.t.sol'
+

--- a/foundry/test/LossDistributorFuzz.t.sol
+++ b/foundry/test/LossDistributorFuzz.t.sol
@@ -62,7 +62,9 @@ contract LossDistributorFuzz is Test {
 
         _distribute(poolId, loss2, total2);
         uint256 perShare2 = uint256(loss2) * ld.PRECISION_FACTOR() / total2;
-        uint256 expected2 = uint256(userPledge) * perShare2 / ld.PRECISION_FACTOR();
+        uint256 expected2 =
+            (uint256(userPledge) * (perShare1 + perShare2) / ld.PRECISION_FACTOR()) -
+            (uint256(userPledge) * perShare1 / ld.PRECISION_FACTOR());
         assertEq(_realize(USER1, poolId, userPledge), expected2);
 
         assertEq(ld.getPendingLosses(USER1, poolId, userPledge), 0);
@@ -82,6 +84,38 @@ contract LossDistributorFuzz is Test {
         _realize(USER1, poolId, pledge1);
         uint256 pending2After = ld.getPendingLosses(USER2, poolId, pledge2);
         assertEq(pending2After, pending2Before);
+    }
+
+    function testFuzz_setRiskManager(address newRM) public {
+        vm.assume(newRM != address(0));
+        ld.setRiskManager(newRM);
+        assertEq(ld.riskManager(), newRM);
+    }
+
+    function testFuzz_setRiskManagerOnlyOwner(address newRM, address caller) public {
+        vm.assume(newRM != address(0) && caller != address(this));
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", caller));
+        ld.setRiskManager(newRM);
+    }
+
+    function testFuzz_setRiskManagerZeroReverts() public {
+        vm.expectRevert(LossDistributor.ZeroAddress.selector);
+        ld.setRiskManager(address(0));
+    }
+
+    function testFuzz_distributeLossZeroNoChange(uint256 poolId, uint96 loss, uint96 total) public {
+        vm.assume(loss == 0 || total == 0);
+        uint256 before = ld.poolLossTrackers(poolId);
+        _distribute(poolId, loss, total);
+        assertEq(ld.poolLossTrackers(poolId), before);
+    }
+
+    function testFuzz_realizeLossesNoPending(uint256 poolId, uint96 pledge) public {
+        vm.prank(RISK_MANAGER);
+        uint256 realized = ld.realizeLosses(USER1, poolId, pledge);
+        assertEq(realized, 0);
+        assertEq(ld.userLossStates(USER1, poolId), 0);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `lossfuzz` profile for foundry
- expand LossDistributor fuzz suite to cover owner logic and zero cases

## Testing
- `FOUNDRY_PROFILE=lossfuzz forge test --match-contract LossDistributorFuzz`
- `FOUNDRY_PROFILE=lossfuzz forge coverage --match-contract LossDistributorFuzz --ir-minimum`


------
https://chatgpt.com/codex/tasks/task_e_6870f65658f4832e945ebd0848b6dd96