### PR TITLE
Add transaction notifications and history

### DIFF
--- a/frontend/app/components/MobileNav.js
+++ b/frontend/app/components/MobileNav.js
@@ -29,6 +29,7 @@ export default function MobileNav() {
   const navigation = [
     { name: "Markets", href: "/markets", icon: BarChart2 },
     { name: "Dashboard", href: "/dashboard", icon: Shield },
+    { name: "Transactions", href: "/transactions", icon: FileText },
         { name: "Backstop Pool", href: "/catpool", icon: Coins },
     { name: "Make a Claim", href: "/claims", icon: AlertTriangle },
     { name: "Analytics", href: "/analytics", icon: Activity },

--- a/frontend/app/components/Navbar.js
+++ b/frontend/app/components/Navbar.js
@@ -78,6 +78,12 @@ export default function Navbar() {
           {/* Desktop Controls */}
           <div className="hidden md:flex items-center space-x-4">
             {/* <CurrencyToggle /> */}
+            <Link
+              href="/transactions"
+              className="px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50"
+            >
+              Transactions
+            </Link>
             <ThemeToggle />
             <ConnectButton />
           </div>

--- a/frontend/app/components/StakeModal.js
+++ b/frontend/app/components/StakeModal.js
@@ -9,7 +9,8 @@ import { getERC20WithSigner, getTokenDecimals, getTokenSymbol } from "../../lib/
 import { getTokenLogo } from "../config/tokenNameMap"
 import Modal from "./Modal"
 import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
-import { getTxExplorerUrl } from "../utils/explorer"
+import { notifyTx } from "../utils/explorer"
+import { useTransactions } from "../../hooks/useTransactions"
 
 export default function StakeModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
@@ -19,6 +20,7 @@ export default function StakeModal({ isOpen, onClose }) {
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
   const tokenAddress = STAKING_TOKEN_ADDRESS
+  const { addTransaction } = useTransactions()
 
   const loadBalance = async () => {
     if (!tokenAddress) return
@@ -67,7 +69,7 @@ export default function StakeModal({ isOpen, onClose }) {
       }
       const tx = await staking.stake(value)
       setTxHash(tx.hash)
-      await tx.wait()
+      await notifyTx(tx, "Stake Tokens", addTransaction)
       setAmount("")
       onClose()
     } catch (err) {

--- a/frontend/app/components/UnstakeModal.js
+++ b/frontend/app/components/UnstakeModal.js
@@ -9,7 +9,8 @@ import { getERC20WithSigner, getTokenDecimals, getTokenSymbol } from "../../lib/
 import { getTokenLogo } from "../config/tokenNameMap"
 import Modal from "./Modal"
 import { STAKING_TOKEN_ADDRESS } from "../config/deployments"
-import { getTxExplorerUrl } from "../utils/explorer"
+import { notifyTx } from "../utils/explorer"
+import { useTransactions } from "../../hooks/useTransactions"
 
 export default function UnstakeModal({ isOpen, onClose }) {
   const [amount, setAmount] = useState("")
@@ -19,6 +20,7 @@ export default function UnstakeModal({ isOpen, onClose }) {
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState(18)
   const tokenAddress = STAKING_TOKEN_ADDRESS
+  const { addTransaction } = useTransactions()
 
   const loadBalance = async () => {
     if (!tokenAddress) return
@@ -59,7 +61,7 @@ export default function UnstakeModal({ isOpen, onClose }) {
       const staking = await getStakingWithSigner()
       const tx = await staking.unstake(ethers.utils.parseUnits(amount, decimals))
       setTxHash(tx.hash)
-      await tx.wait()
+      await notifyTx(tx, "Unstake Tokens", addTransaction)
       setAmount("")
       onClose()
     } catch (err) {

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -3,9 +3,10 @@ import { Inter } from "next/font/google"
 import "../app/globals.css"
 import { Providers } from "./providers" // Import the JS component
 
-import Navbar from "./components/Navbar" // Ensure paths are correct
-import Sidebar from "./components/Sidebar" // Ensure paths are correct
+import Navbar from "./components/Navbar"
+import Sidebar from "./components/Sidebar"
 import { Toaster } from "../components/ui/toaster"
+import { TransactionsProvider } from "../hooks/useTransactions"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -24,16 +25,16 @@ export default function RootLayout({ children }) {
       </head>
       <body className={inter.className}>
         <Providers>
-          {" "}
-          {/* Use the JS Providers component */}
-          <Toaster />
-          <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900">
-            <Navbar />
-            <div className="flex flex-1">
-              <Sidebar />
-              <main className="flex-1 p-4 md:p-6 lg:p-8 pt-20 md:ml-64">{children}</main>
+          <TransactionsProvider>
+            <Toaster />
+            <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900">
+              <Navbar />
+              <div className="flex flex-1">
+                <Sidebar />
+                <main className="flex-1 p-4 md:p-6 lg:p-8 pt-20 md:ml-64">{children}</main>
+              </div>
             </div>
-          </div>
+          </TransactionsProvider>
         </Providers>
       </body>
     </html>

--- a/frontend/app/transactions/page.js
+++ b/frontend/app/transactions/page.js
@@ -1,0 +1,30 @@
+"use client"
+import { useTransactions } from "../../hooks/useTransactions"
+import { getTxExplorerUrl } from "../utils/explorer"
+
+export default function TransactionsPage() {
+  const { transactions } = useTransactions() || { transactions: [] }
+
+  return (
+    <div className="container mx-auto max-w-7xl">
+      <h1 className="text-3xl font-bold mb-6">Transaction History</h1>
+      {transactions.length === 0 ? (
+        <p>No transactions yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {transactions.map((tx, idx) => (
+            <li key={idx} className="flex items-center justify-between p-4 border rounded-lg bg-white dark:bg-gray-800">
+              <div>
+                <p className="font-medium">{tx.name}</p>
+                <p className="text-xs text-gray-500">{new Date(tx.timestamp).toLocaleString()}</p>
+              </div>
+              <a href={getTxExplorerUrl(tx.hash)} target="_blank" rel="noopener noreferrer" className="underline text-blue-600">
+                View
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/utils/explorer.js
+++ b/frontend/app/utils/explorer.js
@@ -2,18 +2,42 @@ import React from 'react'
 import { config } from '../config'
 import { toast } from '@/hooks/use-toast'
 
+// Helper used by tx notifications
 export const getTxExplorerUrl = (hash) => {
   const base = config?.chains?.[0]?.blockExplorers?.default?.url || 'https://basescan.org'
   return `${base}/tx/${hash}`
 }
 
-export const notifyTx = (hash) => {
-  toast({
-    title: 'Transaction Submitted',
+export const notifyTx = async (tx, name, addTx) => {
+  const url = getTxExplorerUrl(tx.hash)
+  const { update, dismiss } = toast({
+    title: `${name} Submitted`,
     description: (
-      <a href={getTxExplorerUrl(hash)} target="_blank" rel="noopener noreferrer" className="underline">
+      <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
         View on block explorer
       </a>
     ),
   })
+  addTx && addTx({ hash: tx.hash, name, status: 'submitted', timestamp: Date.now() })
+  try {
+    await tx.wait()
+    update({
+      title: `${name} Confirmed`,
+      description: (
+        <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
+          View on block explorer
+        </a>
+      ),
+    })
+    addTx && addTx({ hash: tx.hash, name, status: 'confirmed', timestamp: Date.now() })
+  } catch (err) {
+    update({
+      variant: 'destructive',
+      title: `${name} Failed`,
+      description: err.message,
+    })
+  }
+  setTimeout(() => dismiss(), 10000)
 }
+
+

--- a/frontend/hooks/useTransactions.js
+++ b/frontend/hooks/useTransactions.js
@@ -1,0 +1,34 @@
+"use client"
+import { createContext, useContext, useEffect, useState } from "react"
+
+const TxContext = createContext({ transactions: [], addTransaction: () => {} })
+const STORAGE_KEY = "txHistory"
+
+export function TransactionsProvider({ children }) {
+  const [transactions, setTransactions] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      try {
+        setTransactions(JSON.parse(stored))
+      } catch {}
+    }
+  }, [])
+
+  const addTransaction = (tx) => {
+    setTransactions((prev) => {
+      const updated = [tx, ...prev].slice(0, 20)
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated))
+      return updated
+    })
+  }
+
+  return (
+    <TxContext.Provider value={{ transactions, addTransaction }}>
+      {children}
+    </TxContext.Provider>
+  )
+}
+
+export const useTransactions = () => useContext(TxContext)


### PR DESCRIPTION
## Summary
- record recent transactions in a new `useTransactions` hook
- show toast notifications for submitted transactions and hide them 10s after confirmation
- add Transactions page and navigation links
- display transaction toasts from stake/unstake modals
- wrap app with `TransactionsProvider`

## Testing
- `npm test` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_6870fa572994832ea3361e75464594a6