### PR TITLE
Increase PolicyNFT fuzz test coverage

### DIFF
--- a/fuzz/test/PolicyNFTFuzz.t.sol
+++ b/fuzz/test/PolicyNFTFuzz.t.sol
@@ -32,6 +32,14 @@ contract PolicyNFTFuzz is Test {
         nft.setPolicyManagerAddress(address(0));
     }
 
+    function testMintReturnValue() public {
+        nft.setPolicyManagerAddress(manager);
+        vm.prank(manager);
+        uint256 id = nft.mint(user, 1, 42, 0, 0, 0);
+        assertEq(id, 1);
+        assertEq(nft.nextId(), 2);
+    }
+
     function testFuzz_MintStoresPolicy(
         address to,
         uint256 pid,


### PR DESCRIPTION
## Summary
- add deterministic `testMintReturnValue` to `PolicyNFTFuzz.t.sol`
- verify mint increments ID and returns value

## Testing
- `forge coverage --match-path test/PolicyNFTFuzz.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_687102d76884832ea3ce3c005f5bf601