### PR TITLE
Fix inheritance and declare constants

### DIFF
--- a/contracts/MaliciousAdapter.sol
+++ b/contracts/MaliciousAdapter.sol
@@ -6,8 +6,8 @@ interface ICatPool {
     function withdrawLiquidity(uint256 shareAmount) external;
 }
 contract MaliciousAdapter {
-    ICatPool catPool;
-    IERC20 public asset;
+    ICatPool public immutable catPool;
+    IERC20 public immutable asset;
     uint256 sharesToBurn;
     constructor(address _catPool, address _asset) {
         catPool = ICatPool(_catPool);

--- a/contracts/MaliciousRecipient.sol
+++ b/contracts/MaliciousRecipient.sol
@@ -4,8 +4,8 @@ interface ICommittee {
     function claimReward(uint256 _proposalId) external;
 }
 contract MaliciousRecipient {
-    ICommittee committee;
-    uint256 proposalId;
+    ICommittee public immutable committee;
+    uint256 public immutable proposalId;
     constructor(address _committee, uint256 _proposalId) payable {
         committee = ICommittee(_committee);
         proposalId = _proposalId;

--- a/contracts/MaliciousToken.sol
+++ b/contracts/MaliciousToken.sol
@@ -5,7 +5,7 @@ interface ICatPool {
     function depositLiquidity(uint256 usdcAmount) external;
 }
 contract MaliciousToken {
-    ICatPool catPool;
+    ICatPool public immutable catPool;
     uint256 amount;
     uint256 yieldChoice;
     constructor(address _catPool) {

--- a/contracts/adapters/AaveV3Adapter.sol
+++ b/contracts/adapters/AaveV3Adapter.sol
@@ -5,11 +5,12 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IYieldAdapter.sol";
+import "../interfaces/IYieldAdapterEmergency.sol";
 import "../interfaces/IPoolAddressesProvider.sol";
 import "../interfaces/IPool.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
-contract AaveV3Adapter is IYieldAdapter, Ownable {
+contract AaveV3Adapter is IYieldAdapter, IYieldAdapterEmergency, Ownable {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable underlyingToken;

--- a/contracts/adapters/CompoundV3Adapter.sol
+++ b/contracts/adapters/CompoundV3Adapter.sol
@@ -6,10 +6,11 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "../interfaces/IYieldAdapter.sol";
+import "../interfaces/IYieldAdapterEmergency.sol";
 import "../interfaces/IComet.sol";
 import "../interfaces/ICometWithRates.sol";
 
-contract CompoundV3Adapter is IYieldAdapter, Ownable, ReentrancyGuard {
+contract CompoundV3Adapter is IYieldAdapter, IYieldAdapterEmergency, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable underlyingToken;

--- a/contracts/core/CapitalPool.sol
+++ b/contracts/core/CapitalPool.sol
@@ -54,7 +54,7 @@ contract CapitalPool is ReentrancyGuard, Ownable {
 
     uint256 public totalMasterSharesSystem;
     uint256 public totalSystemValue;
-    IERC20 public underlyingAsset;
+    IERC20 public immutable underlyingAsset;
 
     /* ───────────────────────── Modifiers & Errors ──────────────────────── */
     modifier onlyRiskManager() {
@@ -333,7 +333,8 @@ contract CapitalPool is ReentrancyGuard, Ownable {
     /* ─────────────────── NAV Synchronization (Keeper Function) ─────────────────── */
     function syncYieldAndAdjustSystemValue() external nonReentrant {
         uint256 newCalculatedTotalSystemValue = 0;
-        for (uint i = 0; i < activeYieldAdapterAddresses.length; i++) {
+        uint256 adaptersLength = activeYieldAdapterAddresses.length;
+        for (uint i = 0; i < adaptersLength; i++) {
             address adapterAddress = activeYieldAdapterAddresses[i];
             try IYieldAdapter(adapterAddress).getCurrentValueHeld() returns (uint256 valueInAdapter) {
                 newCalculatedTotalSystemValue += valueInAdapter;

--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -14,6 +14,8 @@ import "../interfaces/IBackstopPool.sol";
 import "../interfaces/ILossDistributor.sol";
 import "../interfaces/IPolicyManager.sol";
 import "../interfaces/IRewardDistributor.sol";
+import "../MaliciousPoolRegistry.sol"; // IRiskManager interface
+import "../interfaces/IRiskManager_PM_Hook.sol";
 
 /**
  * @title RiskManager
@@ -21,7 +23,7 @@ import "../interfaces/IRewardDistributor.sol";
  * @notice A lean orchestrator for a decentralized insurance protocol. It manages capital allocation,
  * claim processing, and liquidations by coordinating with specialized satellite contracts.
  */
-contract RiskManager is Ownable, ReentrancyGuard {
+contract RiskManager is Ownable, ReentrancyGuard, IRiskManager, IRiskManager_PM_Hook {
     using SafeERC20 for IERC20;
 
     /* ───────────────────────── State Variables ───────────────────────── */
@@ -324,7 +326,7 @@ contract RiskManager is Ownable, ReentrancyGuard {
     
     /* ───────────────── Hooks & State Updaters ───────────────── */
 
-    function updateCoverageSold(uint256 _poolId, uint256 _amount, bool _isSale) public {
+    function updateCoverageSold(uint256 _poolId, uint256 _amount, bool _isSale) external {
         if(msg.sender != policyManager) revert NotPolicyManager();
         poolRegistry.updateCoverageSold(_poolId, _amount, _isSale);
     }

--- a/contracts/external/BackstopPool.sol
+++ b/contracts/external/BackstopPool.sol
@@ -9,8 +9,10 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../tokens/CatShare.sol"; // Assumes CatShare.sol is in a sub-directory
 import "../interfaces/IYieldAdapter.sol";
 import "../interfaces/IRewardDistributor.sol";
+import "../interfaces/IBackstopPool.sol";
+import "../MaliciousAdapter.sol"; // ICatPool interface
 
-contract BackstopPool is Ownable, ReentrancyGuard {
+contract BackstopPool is Ownable, ReentrancyGuard, ICatPool, IBackstopPool {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable usdc;

--- a/contracts/governance/Committee.sol
+++ b/contracts/governance/Committee.sol
@@ -18,14 +18,14 @@ contract Committee is Ownable, ReentrancyGuard {
     IERC20 public immutable governanceToken;
 
     uint256 public proposalCounter;
-    uint256 public votingPeriod;
-    uint256 public challengePeriod; // e.g., 7 days
-    uint256 public quorumBps;
-    uint256 public minBondAmount = 1000 ether;
-    uint256 public maxBondAmount = 2500 ether;
-    uint256 public minProposerFeeBps = 1000; // 10%
-    uint256 public maxProposerFeeBps = 2500; // 25%
-    uint256 public slashPercentageBps;
+    uint256 public immutable votingPeriod;
+    uint256 public immutable challengePeriod; // e.g., 7 days
+    uint256 public immutable quorumBps;
+    uint256 public constant minBondAmount = 1000 ether;
+    uint256 public constant maxBondAmount = 2500 ether;
+    uint256 public constant minProposerFeeBps = 1000; // 10%
+    uint256 public constant maxProposerFeeBps = 2500; // 25%
+    uint256 public immutable slashPercentageBps;
 
     enum ProposalType { Unpause, Pause }
     enum VoteOption { None, Against, For }


### PR DESCRIPTION
## Summary
- implement emergency adapter interface for AaveV3Adapter and CompoundV3Adapter
- make RiskManager implement IRiskManager and IRiskManager_PM_Hook
- cache array length in CapitalPool sync function
- declare constant/immutable variables for Committee and other contracts
- implement IBackstopPool and ICatPool in BackstopPool
- implement IPolicyNFT for PolicyNFT
- mark malicious contracts' variables immutable

## Testing
- `npx hardhat compile`
- `npm test --silent` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_687119c1c284832ebca21c528617e55b