### PR TITLE
Fix imports for malicious contracts

### DIFF
--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -14,6 +14,7 @@ import "../interfaces/IBackstopPool.sol";
 import "../interfaces/ILossDistributor.sol";
 import "../interfaces/IPolicyManager.sol";
 import "../interfaces/IRewardDistributor.sol";
+import "../interfaces/IRiskManager.sol";
 // import "../MaliciousPoolRegistry.sol"; // IRiskManager interface
 import "../interfaces/IRiskManager_PM_Hook.sol";
 

--- a/contracts/external/BackstopPool.sol
+++ b/contracts/external/BackstopPool.sol
@@ -10,9 +10,7 @@ import "../tokens/CatShare.sol"; // Assumes CatShare.sol is in a sub-directory
 import "../interfaces/IYieldAdapter.sol";
 import "../interfaces/IRewardDistributor.sol";
 import "../interfaces/IBackstopPool.sol";
-import "../MaliciousAdapter.sol"; // ICatPool interface
-
-contract BackstopPool is Ownable, ReentrancyGuard, ICatPool, IBackstopPool {
+contract BackstopPool is Ownable, ReentrancyGuard, IBackstopPool {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable usdc;


### PR DESCRIPTION
## Summary
- clean up BackstopPool dependencies
- add missing IRiskManager import

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: 129 failing)*
- `npm run slither` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687122b00588832e8c6b47eab215e74f