### PR TITLE
Fix interfaces and redundant code

### DIFF
--- a/contracts/adapters/AaveV3Adapter.sol
+++ b/contracts/adapters/AaveV3Adapter.sol
@@ -12,7 +12,7 @@ import "../interfaces/IPool.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
 
-contract AaveV3Adapter is IYieldAdapter, Ownable, ReentrancyGuard {
+contract AaveV3Adapter is IYieldAdapter, IYieldAdapterEmergency, Ownable, ReentrancyGuard {
 
     using SafeERC20 for IERC20;
 
@@ -95,7 +95,13 @@ contract AaveV3Adapter is IYieldAdapter, Ownable, ReentrancyGuard {
         return liquid + aTokenBal;
     }
 
-    function emergencyTransfer(address _to, uint256 _amount) external onlyCapitalPool nonReentrant returns (uint256) {
+    function emergencyTransfer(address _to, uint256 _amount)
+        external
+        override
+        onlyCapitalPool
+        nonReentrant
+        returns (uint256)
+    {
         uint256 bal = aToken.balanceOf(address(this));
         uint256 amt = Math.min(_amount, bal);
         if (amt > 0) {

--- a/contracts/core/RiskManager.sol
+++ b/contracts/core/RiskManager.sol
@@ -414,7 +414,6 @@ contract RiskManager is Ownable, ReentrancyGuard, IRiskManager, IRiskManager_PM_
                     address(protocolToken),
                     underwriterPoolPledge[msg.sender][poolId]
                 );
-                claimed;
             }
         }
     }


### PR DESCRIPTION
## Summary
- implement IYieldAdapterEmergency in AaveV3Adapter
- remove a redundant statement in RiskManager

## Testing
- `npm test` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68713f291614832e9702892bdd5ed503