### PR TITLE
Improve safety checks and payout tracking

### DIFF
--- a/contracts/adapters/SimpleYieldAdapter.sol
+++ b/contracts/adapters/SimpleYieldAdapter.sol
@@ -26,6 +26,7 @@ contract SimpleYieldAdapter is IYieldAdapter, Ownable, ReentrancyGuard {
 
     constructor(address _asset, address _depositor, address _owner) Ownable(_owner) {
         require(_asset != address(0), "Adapter: asset zero");
+        require(_depositor != address(0), "Adapter: zero depositor");
         underlyingToken = IERC20(_asset);
         depositor = _depositor;
     }

--- a/contracts/core/CapitalPool.sol
+++ b/contracts/core/CapitalPool.sol
@@ -97,6 +97,7 @@ contract CapitalPool is ReentrancyGuard, Ownable {
     event SystemValueSynced(uint256 newTotalSystemValue, uint256 oldTotalSystemValue);
     event AdapterCallFailed(address indexed adapterAddress, string functionCalled, string reason);
     event UnderwriterNoticePeriodSet(uint256 newPeriod);
+    event PayoutExecuted(address indexed claimant, uint256 claimantAmount, address indexed feeRecipient, uint256 feeAmount, uint256 newTotalSystemValue);
 
 
     /* ───────────────────── Constructor ─────────────────────────── */
@@ -304,6 +305,7 @@ contract CapitalPool is ReentrancyGuard, Ownable {
         if (_payoutData.feeAmount > 0 && _payoutData.feeRecipient != address(0)) {
             underlyingAsset.safeTransfer(_payoutData.feeRecipient, _payoutData.feeAmount);
         }
+        emit PayoutExecuted(_payoutData.claimant, _payoutData.claimantAmount, _payoutData.feeRecipient, _payoutData.feeAmount, totalSystemValue);
     }
 
     function applyLosses(address _underwriter, uint256 _principalLossAmount) external nonReentrant onlyRiskManager {

--- a/contracts/tokens/PolicyNFT.sol
+++ b/contracts/tokens/PolicyNFT.sol
@@ -31,6 +31,7 @@ contract PolicyNFT is ERC721URIStorage, Ownable, IPolicyNFT {
     }
 
     constructor(address _initialPolicyManager, address initialOwner) ERC721("Policy", "PCOVER") Ownable(initialOwner) {
+        require(_initialPolicyManager != address(0), "PolicyNFT: PolicyManager address cannot be zero");
         policyManagerContract = _initialPolicyManager;
     }
 


### PR DESCRIPTION
## Summary
- validate non-zero addresses in `SimpleYieldAdapter` and `PolicyNFT` constructors
- emit `PayoutExecuted` when payouts reduce system value

## Testing
- `npx hardhat compile`
- `npx hardhat test test/PolicyNFT.test.js` *(fails: PolicyNFT: PolicyManager address cannot be zero)*

------
https://chatgpt.com/codex/tasks/task_e_687143a52a7c832e85fc84ae2b44d3f4