### PR TITLE
Add Manticore symbolic execution example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ lib/
 !lib/forge-std/
 foundry/out
 
+
+# Manticore output
+/mcore_*

--- a/README.md
+++ b/README.md
@@ -348,3 +348,4 @@ graph TD
     Underwriter -.->|capital reduced| CapitalPool
     BackstopPool -->|protocol assets| RewardDistributor
 ```
+\n## Manticore Symbolic Execution\n\nInstall Manticore (requires Python 3.10 or later) and run the example script to explore symbolic paths in the test contracts.\n\n```bash\npython3 -m pip install manticore\nnpm run test:manticore\n```\n

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "configure:params": "hardhat run scripts/configure-parameters.js --network base",
     "slither:test": "slither . --compile-force-framework hardhat --exclude naming-convention --filter-paths 'test|node_modules/@openzeppelin/contracts'",
     "test:forge": "forge test",
-    "test:forge:fuzz": "forge test -C fuzz"
+    "test:forge:fuzz": "forge test -C fuzz",
+    "test:manticore": "python3 scripts/manticore_example.py"
   },
   "keywords": [],
   "author": "",

--- a/scripts/manticore_example.py
+++ b/scripts/manticore_example.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Example Manticore script for symbolic execution.
+
+This deploys the `MockERC20` test contract and explores symbolic calls to
+`mint` and `burn`. Results are written to a local `mcore_*` directory.
+
+Usage:
+    python3 scripts/manticore_example.py
+"""
+
+from manticore.ethereum import ManticoreEVM
+
+# create blockchain with a funded user account
+m = ManticoreEVM()
+user = m.create_account(balance=10**18)
+
+# load solidity source
+with open("contracts/test/MockERC20.sol", "r") as f:
+    source = f.read()
+
+# deploy the contract with constructor arguments
+token = m.solidity_create_contract(
+    source,
+    owner=user,
+    contract_name="MockERC20",
+    args=("MockToken", "MOCK", 18),
+)
+
+# make symbolic mint/burn amounts
+amount = m.make_symbolic_value(name="amount")
+
+# owner mints to user then burns from user
+token.mint(user, amount)
+token.burn(user, amount)
+
+# explore all paths
+m.run()
+print(f"Results saved in {m.workspace}")


### PR DESCRIPTION
## Summary
- add `manticore_example.py` to demo symbolic execution with Manticore
- ignore Manticore output directories
- expose `test:manticore` npm script
- document how to run the example

## Testing
- `npm test` *(fails: 130 failing)*
- `npm run test:manticore` *(fails: ModuleNotFoundError: No module named 'manticore')*


------
https://chatgpt.com/codex/tasks/task_e_68714513c514832e86f842bdf58b4da9