### PR TITLE
Fix Slither parameter naming warnings

### DIFF
--- a/contracts/external/BackstopPool.sol
+++ b/contracts/external/BackstopPool.sol
@@ -100,33 +100,33 @@ contract BackstopPool is Ownable, ReentrancyGuard, IBackstopPool {
 
     /* ───────────────────── Admin Functions ───────────────────── */
 
-    function setRiskManagerAddress(address _newRiskManagerAddress) external onlyOwner {
-        require(_newRiskManagerAddress != address(0), "CIP: Address cannot be zero");
-        riskManagerAddress = _newRiskManagerAddress;
-        emit RiskManagerAddressSet(_newRiskManagerAddress);
+    function setRiskManagerAddress(address newRiskManagerAddress) external onlyOwner {
+        require(newRiskManagerAddress != address(0), "CIP: Address cannot be zero");
+        riskManagerAddress = newRiskManagerAddress;
+        emit RiskManagerAddressSet(newRiskManagerAddress);
     }
     
-    function setCapitalPoolAddress(address _newCapitalPoolAddress) external onlyOwner {
-        require(_newCapitalPoolAddress != address(0), "CIP: Address cannot be zero");
-        capitalPoolAddress = _newCapitalPoolAddress;
-        emit CapitalPoolAddressSet(_newCapitalPoolAddress);
+    function setCapitalPoolAddress(address newCapitalPoolAddress) external onlyOwner {
+        require(newCapitalPoolAddress != address(0), "CIP: Address cannot be zero");
+        capitalPoolAddress = newCapitalPoolAddress;
+        emit CapitalPoolAddressSet(newCapitalPoolAddress);
     }
 
-    function setPolicyManagerAddress(address _newPolicyManagerAddress) external onlyOwner {
-        require(_newPolicyManagerAddress != address(0), "CIP: Address cannot be zero");
-        policyManagerAddress = _newPolicyManagerAddress;
-        emit PolicyManagerAddressSet(_newPolicyManagerAddress);
+    function setPolicyManagerAddress(address newPolicyManagerAddress) external onlyOwner {
+        require(newPolicyManagerAddress != address(0), "CIP: Address cannot be zero");
+        policyManagerAddress = newPolicyManagerAddress;
+        emit PolicyManagerAddressSet(newPolicyManagerAddress);
     }
     
-    function setRewardDistributor(address _rewardDistributor) external onlyOwner {
-        require(_rewardDistributor != address(0), "CIP: Address cannot be zero");
-        rewardDistributor = IRewardDistributor(_rewardDistributor);
-        emit RewardDistributorSet(_rewardDistributor);
+    function setRewardDistributor(address rewardDistributorAddress) external onlyOwner {
+        require(rewardDistributorAddress != address(0), "CIP: Address cannot be zero");
+        rewardDistributor = IRewardDistributor(rewardDistributorAddress);
+        emit RewardDistributorSet(rewardDistributorAddress);
     }
 
-    function setAdapter(address _newAdapterAddress) external onlyOwner nonReentrant {
+    function setAdapter(address newAdapterAddress) external onlyOwner nonReentrant {
         IYieldAdapter oldAdapter = adapter;
-        adapter = IYieldAdapter(_newAdapterAddress);
+        adapter = IYieldAdapter(newAdapterAddress);
 
         if (address(oldAdapter) != address(0)) {
             uint256 balanceInOldAdapter = oldAdapter.getCurrentValueHeld();
@@ -143,7 +143,7 @@ contract BackstopPool is Ownable, ReentrancyGuard, IBackstopPool {
             usdc.forceApprove(address(adapter), 0);
             usdc.forceApprove(address(adapter), type(uint256).max);
         }
-        emit AdapterChanged(_newAdapterAddress);
+        emit AdapterChanged(newAdapterAddress);
     }
 
     function flushToAdapter(uint256 amount) external onlyOwner nonReentrant {

--- a/contracts/governance/Committee.sol
+++ b/contracts/governance/Committee.sol
@@ -85,41 +85,41 @@ contract Committee is Ownable, ReentrancyGuard {
         slashPercentageBps = _slashPercentageBps;
     }
         
-    function createProposal(uint256 _poolId, ProposalType _pType, uint256 _bondAmount) external nonReentrant returns (uint256) {
+    function createProposal(uint256 poolId, ProposalType pType, uint256 bondAmount) external nonReentrant returns (uint256) {
         require(stakingContract.stakedBalance(msg.sender) > 0, "Must be a staker");
-        require(!activeProposalForPool[_poolId], "Proposal already exists");
+        require(!activeProposalForPool[poolId], "Proposal already exists");
 
         uint256 proposalId = ++proposalCounter;
         Proposal storage p = proposals[proposalId];
 
         p.id = proposalId;
         p.proposer = msg.sender;
-        p.poolId = _poolId;
-        p.pType = _pType;
+        p.poolId = poolId;
+        p.pType = pType;
         p.creationTime = block.timestamp;
         p.votingDeadline = block.timestamp + votingPeriod;
         p.status = ProposalStatus.Active;
-        activeProposalForPool[_poolId] = true;
+        activeProposalForPool[poolId] = true;
 
-        if (_pType == ProposalType.Pause) {
-            require(_bondAmount >= minBondAmount && _bondAmount <= maxBondAmount, "Invalid bond");
-            p.bondAmount = _bondAmount;
-            p.proposerFeeShareBps = _calculateFeeShare(_bondAmount);
-            governanceToken.safeTransferFrom(msg.sender, address(this), _bondAmount);
+        if (pType == ProposalType.Pause) {
+            require(bondAmount >= minBondAmount && bondAmount <= maxBondAmount, "Invalid bond");
+            p.bondAmount = bondAmount;
+            p.proposerFeeShareBps = _calculateFeeShare(bondAmount);
+            governanceToken.safeTransferFrom(msg.sender, address(this), bondAmount);
         } else {
-            require(_bondAmount == 0, "No bond for unpause");
+            require(bondAmount == 0, "No bond for unpause");
             p.proposerFeeShareBps = 0;
         }
 
-        emit ProposalCreated(proposalId, msg.sender, _poolId, _pType);
+        emit ProposalCreated(proposalId, msg.sender, poolId, pType);
         return proposalId;
     }
 
-    function vote(uint256 _proposalId, VoteOption _vote) external nonReentrant {
-        Proposal storage p = proposals[_proposalId];
+    function vote(uint256 proposalId, VoteOption voteOption) external nonReentrant {
+        Proposal storage p = proposals[proposalId];
         require(p.status == ProposalStatus.Active, "Proposal not active");
         require(block.timestamp < p.votingDeadline, "Voting ended");
-        require(_vote != VoteOption.None, "Invalid vote option");
+        require(voteOption != VoteOption.None, "Invalid vote option");
 
         VoteOption previousVote = p.votes[msg.sender];
         uint256 previousWeight = p.voterWeight[msg.sender];
@@ -133,59 +133,59 @@ contract Committee is Ownable, ReentrancyGuard {
         }
 
         // Record new vote and weight
-        p.votes[msg.sender] = _vote;
+        p.votes[msg.sender] = voteOption;
         p.voterWeight[msg.sender] = currentWeight;
 
-        if (_vote == VoteOption.For) {
+        if (voteOption == VoteOption.For) {
             p.forVotes += currentWeight;
         } else {
             p.againstVotes += currentWeight;
         }
 
-        stakingContract.recordVote(msg.sender, _proposalId);
+        stakingContract.recordVote(msg.sender, proposalId);
 
-        emit Voted(_proposalId, msg.sender, _vote, currentWeight);
+        emit Voted(proposalId, msg.sender, voteOption, currentWeight);
     }
 
-    function updateVoteWeight(address _voter, uint256 _proposalId, uint256 _newWeight) external nonReentrant {
+    function updateVoteWeight(address voter, uint256 proposalId, uint256 newWeight) external nonReentrant {
         require(msg.sender == address(stakingContract), "Not staking contract");
-        Proposal storage p = proposals[_proposalId];
+        Proposal storage p = proposals[proposalId];
         if (p.status != ProposalStatus.Active || block.timestamp >= p.votingDeadline) {
             return;
         }
 
-        VoteOption voteChoice = p.votes[_voter];
+        VoteOption voteChoice = p.votes[voter];
         if (voteChoice == VoteOption.None) {
             return;
         }
 
-        uint256 prevWeight = p.voterWeight[_voter];
-        if (prevWeight == _newWeight) {
+        uint256 prevWeight = p.voterWeight[voter];
+        if (prevWeight == newWeight) {
             return;
         }
 
         if (voteChoice == VoteOption.For) {
-            if (_newWeight > prevWeight) {
-                p.forVotes += _newWeight - prevWeight;
+            if (newWeight > prevWeight) {
+                p.forVotes += newWeight - prevWeight;
             } else {
-                p.forVotes -= prevWeight - _newWeight;
+                p.forVotes -= prevWeight - newWeight;
             }
         } else {
-            if (_newWeight > prevWeight) {
-                p.againstVotes += _newWeight - prevWeight;
+            if (newWeight > prevWeight) {
+                p.againstVotes += newWeight - prevWeight;
             } else {
-                p.againstVotes -= prevWeight - _newWeight;
+                p.againstVotes -= prevWeight - newWeight;
             }
         }
 
-        p.voterWeight[_voter] = _newWeight;
+        p.voterWeight[voter] = newWeight;
     }
 
     /**
      * @notice REFACTORED: This function now acts as a dispatcher to prevent "stack too deep" errors.
      */
-    function executeProposal(uint256 _proposalId) external nonReentrant {
-        Proposal storage p = proposals[_proposalId];
+    function executeProposal(uint256 proposalId) external nonReentrant {
+        Proposal storage p = proposals[proposalId];
         require(p.status == ProposalStatus.Active, "Proposal not active for execution");
         require(block.timestamp >= p.votingDeadline, "Voting not over");
         
@@ -196,7 +196,7 @@ contract Committee is Ownable, ReentrancyGuard {
             _handleDefeatedProposal(p);
         } else {
             _handleSuccessfulProposal(p);
-            emit ProposalExecuted(_proposalId);
+            emit ProposalExecuted(proposalId);
         }
     }
 
@@ -231,8 +231,8 @@ contract Committee is Ownable, ReentrancyGuard {
         }
     }
     
-    function resolvePauseBond(uint256 _proposalId) external nonReentrant {
-        Proposal storage p = proposals[_proposalId];
+    function resolvePauseBond(uint256 proposalId) external nonReentrant {
+        Proposal storage p = proposals[proposalId];
         require(p.pType == ProposalType.Pause, "Not a pause proposal");
         require(p.status == ProposalStatus.Challenged, "Not in challenge phase");
         require(block.timestamp >= p.challengeDeadline, "Challenge period not over");
@@ -242,27 +242,27 @@ contract Committee is Ownable, ReentrancyGuard {
 
         if (p.totalRewardFees > 0) {
             governanceToken.safeTransfer(p.proposer, p.bondAmount);
-            emit BondResolved(_proposalId, false);
+            emit BondResolved(proposalId, false);
         } else {
             // entire bond is slashed and kept in the contract
-            emit BondResolved(_proposalId, true);
+            emit BondResolved(proposalId, true);
         }
     }
 
     /* ───────────────────── Reward Functions ───────────────────── */
 
-    function receiveFees(uint256 _proposalId) external payable onlyRiskManager {
-        proposals[_proposalId].totalRewardFees += msg.value;
+    function receiveFees(uint256 proposalId) external payable onlyRiskManager {
+        proposals[proposalId].totalRewardFees += msg.value;
     }
 
-    function claimReward(uint256 _proposalId) external nonReentrant {
-        Proposal storage p = proposals[_proposalId];
+    function claimReward(uint256 proposalId) external nonReentrant {
+        Proposal storage p = proposals[proposalId];
         require(p.status == ProposalStatus.Resolved || p.status == ProposalStatus.Executed, "Proposal not resolved");
         require(p.totalRewardFees > 0, "No rewards to claim");
         require(p.votes[msg.sender] == VoteOption.For, "Must have voted 'For' to claim rewards");
-        require(!hasClaimedReward[_proposalId][msg.sender], "Reward already claimed");
+        require(!hasClaimedReward[proposalId][msg.sender], "Reward already claimed");
 
-        hasClaimedReward[_proposalId][msg.sender] = true;
+        hasClaimedReward[proposalId][msg.sender] = true;
         uint256 totalFees = p.totalRewardFees;
         uint256 proposerBonus = 0;
         
@@ -276,7 +276,7 @@ contract Committee is Ownable, ReentrancyGuard {
 
         payable(msg.sender).sendValue(userReward);
         
-        emit RewardClaimed(_proposalId, msg.sender, userReward);
+        emit RewardClaimed(proposalId, msg.sender, userReward);
     }
 
     function _calculateFeeShare(uint256 _bondAmount) internal view returns (uint256) {
@@ -291,8 +291,8 @@ contract Committee is Ownable, ReentrancyGuard {
         return minProposerFeeBps + ((_bondAmount - minBondAmount) * bpsSpan) / span;
     }
 
-    function isProposalFinalized(uint256 _proposalId) external view returns (bool) {
-        Proposal storage p = proposals[_proposalId];
+    function isProposalFinalized(uint256 proposalId) external view returns (bool) {
+        Proposal storage p = proposals[proposalId];
         return p.status == ProposalStatus.Defeated || p.status == ProposalStatus.Executed || p.status == ProposalStatus.Resolved;
     }
 }

--- a/contracts/tokens/PolicyNFT.sol
+++ b/contracts/tokens/PolicyNFT.sol
@@ -35,10 +35,10 @@ contract PolicyNFT is ERC721URIStorage, Ownable, IPolicyNFT {
         policyManagerContract = _initialPolicyManager;
     }
 
-    function setPolicyManagerAddress(address _newPolicyManagerAddress) external onlyOwner {
-        require(_newPolicyManagerAddress != address(0), "PolicyNFT: Address cannot be zero");
-        policyManagerContract = _newPolicyManagerAddress;
-        emit PolicyManagerAddressSet(_newPolicyManagerAddress);
+    function setPolicyManagerAddress(address newPolicyManagerAddress) external onlyOwner {
+        require(newPolicyManagerAddress != address(0), "PolicyNFT: Address cannot be zero");
+        policyManagerContract = newPolicyManagerAddress;
+        emit PolicyManagerAddressSet(newPolicyManagerAddress);
     }
 
     /**

--- a/contracts/utils/LossDistributor.sol
+++ b/contracts/utils/LossDistributor.sol
@@ -52,10 +52,10 @@ contract LossDistributor is ILossDistributor, Ownable {
         riskManager = _riskManagerAddress;
     }
 
-    function setRiskManager(address _newRiskManager) external onlyOwner {
-        if (_newRiskManager == address(0)) revert ZeroAddress();
-        riskManager = _newRiskManager;
-        emit RiskManagerAddressSet(_newRiskManager);
+    function setRiskManager(address newRiskManager) external onlyOwner {
+        if (newRiskManager == address(0)) revert ZeroAddress();
+        riskManager = newRiskManager;
+        emit RiskManagerAddressSet(newRiskManager);
     }
 
     /* ───────────────────────── Core Logic ──────────────────────── */

--- a/contracts/utils/RewardDistributor.sol
+++ b/contracts/utils/RewardDistributor.sol
@@ -77,22 +77,22 @@ contract RewardDistributor is IRewardDistributor, Ownable, ReentrancyGuard {
         emit PolicyManagerAddressSet(_policyManagerAddress);
     }
 
-    function setCatPool(address _catPool) external onlyOwner {
-        if (_catPool == address(0)) revert ZeroAddress();
-        catPool = _catPool;
-        emit CatPoolSet(_catPool);
+    function setCatPool(address catPoolAddress) external onlyOwner {
+        if (catPoolAddress == address(0)) revert ZeroAddress();
+        catPool = catPoolAddress;
+        emit CatPoolSet(catPoolAddress);
     }
 
-    function setRiskManager(address _newRiskManager) external onlyOwner {
-        if (_newRiskManager == address(0)) revert ZeroAddress();
-        riskManager = _newRiskManager;
-        emit RiskManagerAddressSet(_newRiskManager);
+    function setRiskManager(address newRiskManager) external onlyOwner {
+        if (newRiskManager == address(0)) revert ZeroAddress();
+        riskManager = newRiskManager;
+        emit RiskManagerAddressSet(newRiskManager);
     }
 
-    function setPolicyManager(address _newPolicyManager) external onlyOwner {
-        if (_newPolicyManager == address(0)) revert ZeroAddress();
-        policyManager = _newPolicyManager;
-        emit PolicyManagerAddressSet(_newPolicyManager);
+    function setPolicyManager(address newPolicyManager) external onlyOwner {
+        if (newPolicyManager == address(0)) revert ZeroAddress();
+        policyManager = newPolicyManager;
+        emit PolicyManagerAddressSet(newPolicyManager);
     }
 
     /* ───────────────────────── Core Logic ──────────────────────── */


### PR DESCRIPTION
## Summary
- ensure solidity parameters use camelCase naming
- adjust documentation to match new parameter names

## Testing
- `npx hardhat test` *(fails: PolicyNFT: PolicyManager address cannot be zero)*

------
https://chatgpt.com/codex/tasks/task_e_6872dff4aae0832e839ce38b34229108