### PR TITLE
Fix compile errors in PoolRegistry

### DIFF
--- a/contracts/core/PoolRegistry.sol
+++ b/contracts/core/PoolRegistry.sol
@@ -30,16 +30,7 @@ contract PoolRegistry is IPoolRegistry, Ownable {
     }
 
 
-    // We define a new struct to hold the returned data for each pool.
-    struct PoolInfo {
-        IERC20 protocolTokenToCover;
-        uint256 totalCapitalPledgedToPool;
-        uint256 totalCoverageSold;
-        uint256 capitalPendingWithdrawal;
-        bool isPaused;
-        address feeRecipient;
-        uint256 claimFeeBps;
-    }
+
 
     PoolData[] public protocolRiskPools;
     address public riskManager;
@@ -158,15 +149,15 @@ contract PoolRegistry is IPoolRegistry, Ownable {
     * @param _poolIds An array of IDs for the pools to query.
     * @return A memory array of PoolInfo structs containing the data for each requested pool.
     */
-    function getMultiplePoolData(uint256[] calldata _poolIds) external view returns (PoolInfo[] memory) {
+    function getMultiplePoolData(uint256[] calldata _poolIds) external view returns (IPoolRegistry.PoolInfo[] memory) {
         uint256 numPools = _poolIds.length;
-        PoolInfo[] memory multiplePoolData = new PoolInfo[](numPools);
+        IPoolRegistry.PoolInfo[] memory multiplePoolData = new IPoolRegistry.PoolInfo[](numPools);
 
         for (uint256 i = 0; i < numPools; i++) {
             uint256 poolId = _poolIds[i];
             PoolData storage pool = protocolRiskPools[poolId];
 
-            multiplePoolData[i] = PoolInfo({
+            multiplePoolData[i] = IPoolRegistry.PoolInfo({
                 protocolTokenToCover: pool.protocolTokenToCover,
                 totalCapitalPledgedToPool: pool.totalCapitalPledgedToPool,
                 totalCoverageSold: pool.totalCoverageSold,

--- a/contracts/test/MockPoolRegistry.sol
+++ b/contracts/test/MockPoolRegistry.sol
@@ -142,5 +142,22 @@ contract MockPoolRegistry is IPoolRegistry, Ownable {
     function setFeeRecipient(uint256 poolId, address recipient) external override {
         pools[poolId].feeRecipient = recipient;
     }
+
+    function getMultiplePoolData(uint256[] calldata poolIds) external view override returns (IPoolRegistry.PoolInfo[] memory infos) {
+        uint256 len = poolIds.length;
+        infos = new IPoolRegistry.PoolInfo[](len);
+        for (uint256 i = 0; i < len; i++) {
+            PoolData storage d = pools[poolIds[i]];
+            infos[i] = IPoolRegistry.PoolInfo({
+                protocolTokenToCover: d.protocolTokenToCover,
+                totalCapitalPledgedToPool: d.totalCapitalPledgedToPool,
+                totalCoverageSold: d.totalCoverageSold,
+                capitalPendingWithdrawal: d.capitalPendingWithdrawal,
+                isPaused: d.isPaused,
+                feeRecipient: d.feeRecipient,
+                claimFeeBps: d.claimFeeBps
+            });
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate `PoolInfo` struct from `PoolRegistry`
- return interface struct for `getMultiplePoolData`
- implement `getMultiplePoolData` in `MockPoolRegistry`

## Testing
- `npx hardhat test` *(fails: PolicyNFT: PolicyManager address cannot be zero)*
- `forge build` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68736dcbb2dc832eb981b7e6e5613800