### PR TITLE
Fix PoolRegistry naming

### DIFF
--- a/contracts/core/PoolRegistry.sol
+++ b/contracts/core/PoolRegistry.sol
@@ -42,78 +42,78 @@ contract PoolRegistry is IPoolRegistry, Ownable {
         _;
     }
 
-    constructor(address _initialOwner, address _riskManager) Ownable(_initialOwner) {
-        require(_riskManager != address(0), "PR: Zero address");
-        riskManager = _riskManager;
+    constructor(address initialOwner, address riskManagerAddress) Ownable(initialOwner) {
+        require(riskManagerAddress != address(0), "PR: Zero address");
+        riskManager = riskManagerAddress;
     }
 
-    function setRiskManager(address _newRiskManager) external onlyOwner {
-        require(_newRiskManager != address(0), "PR: Zero address");
-        riskManager = _newRiskManager;
-        emit RiskManagerAddressSet(_newRiskManager);
+    function setRiskManager(address newRiskManager) external onlyOwner {
+        require(newRiskManager != address(0), "PR: Zero address");
+        riskManager = newRiskManager;
+        emit RiskManagerAddressSet(newRiskManager);
     }
     
     /* ───────────────────── State Modifying Functions (RM only) ───────────────────── */
 
     function addProtocolRiskPool(
-        address _protocolTokenToCover,
-        RateModel calldata _rateModel,
-        uint256 _claimFeeBps
+        address protocolTokenToCover,
+        RateModel calldata rateModel,
+        uint256 claimFeeBps
     ) external onlyRiskManager returns (uint256) {
         uint256 poolId = protocolRiskPools.length;
         protocolRiskPools.push();
         PoolData storage pool = protocolRiskPools[poolId];
-        pool.protocolTokenToCover = IERC20(_protocolTokenToCover);
-        pool.rateModel = _rateModel;
-        pool.claimFeeBps = _claimFeeBps;
+        pool.protocolTokenToCover = IERC20(protocolTokenToCover);
+        pool.rateModel = rateModel;
+        pool.claimFeeBps = claimFeeBps;
         return poolId;
     }
 
-    function updateCapitalAllocation(uint256 _poolId, address _adapterAddress, uint256 _pledgeAmount, bool _isAllocation) external onlyRiskManager {
-        PoolData storage pool = protocolRiskPools[_poolId];
-        if (_isAllocation) {
-            pool.totalCapitalPledgedToPool += _pledgeAmount;
-            pool.capitalPerAdapter[_adapterAddress] += _pledgeAmount;
-            if (!pool.isAdapterInPool[_adapterAddress]) {
-                pool.isAdapterInPool[_adapterAddress] = true;
-                pool.activeAdapters.push(_adapterAddress);
-                pool.adapterIndex[_adapterAddress] = pool.activeAdapters.length - 1;
+    function updateCapitalAllocation(uint256 poolId, address adapterAddress, uint256 pledgeAmount, bool isAllocation) external onlyRiskManager {
+        PoolData storage pool = protocolRiskPools[poolId];
+        if (isAllocation) {
+            pool.totalCapitalPledgedToPool += pledgeAmount;
+            pool.capitalPerAdapter[adapterAddress] += pledgeAmount;
+            if (!pool.isAdapterInPool[adapterAddress]) {
+                pool.isAdapterInPool[adapterAddress] = true;
+                pool.activeAdapters.push(adapterAddress);
+                pool.adapterIndex[adapterAddress] = pool.activeAdapters.length - 1;
             }
         } else {
-            pool.totalCapitalPledgedToPool -= _pledgeAmount;
-            pool.capitalPerAdapter[_adapterAddress] -= _pledgeAmount;
-            if (pool.capitalPerAdapter[_adapterAddress] == 0) {
-                _removeAdapterFromPool(pool, _adapterAddress);
+            pool.totalCapitalPledgedToPool -= pledgeAmount;
+            pool.capitalPerAdapter[adapterAddress] -= pledgeAmount;
+            if (pool.capitalPerAdapter[adapterAddress] == 0) {
+                _removeAdapterFromPool(pool, adapterAddress);
             }
         }
     }
 
-    function updateCapitalPendingWithdrawal(uint256 _poolId, uint256 _amount, bool _isRequest) external onlyRiskManager {
-        PoolData storage pool = protocolRiskPools[_poolId];
-        if (_isRequest) {
-            pool.capitalPendingWithdrawal += _amount;
+    function updateCapitalPendingWithdrawal(uint256 poolId, uint256 amount, bool isRequest) external onlyRiskManager {
+        PoolData storage pool = protocolRiskPools[poolId];
+        if (isRequest) {
+            pool.capitalPendingWithdrawal += amount;
         } else {
-            pool.capitalPendingWithdrawal -= _amount;
+            pool.capitalPendingWithdrawal -= amount;
         }
     }
 
-    function updateCoverageSold(uint256 _poolId, uint256 _amount, bool _isSale) external onlyRiskManager {
-        PoolData storage pool = protocolRiskPools[_poolId];
-        if (_isSale) {
-            pool.totalCoverageSold += _amount;
+    function updateCoverageSold(uint256 poolId, uint256 amount, bool isSale) external onlyRiskManager {
+        PoolData storage pool = protocolRiskPools[poolId];
+        if (isSale) {
+            pool.totalCoverageSold += amount;
         } else {
-            pool.totalCoverageSold -= _amount;
+            pool.totalCoverageSold -= amount;
         }
     }
 
-    function setPauseState(uint256 _poolId, bool _isPaused) external onlyRiskManager {
-        PoolData storage pool = protocolRiskPools[_poolId];
-        pool.isPaused = _isPaused;
-        pool.pauseTimestamp = _isPaused ? block.timestamp : 0;
+    function setPauseState(uint256 poolId, bool isPaused) external onlyRiskManager {
+        PoolData storage pool = protocolRiskPools[poolId];
+        pool.isPaused = isPaused;
+        pool.pauseTimestamp = isPaused ? block.timestamp : 0;
     }
     
-    function setFeeRecipient(uint256 _poolId, address _recipient) external onlyRiskManager {
-        protocolRiskPools[_poolId].feeRecipient = _recipient;
+    function setFeeRecipient(uint256 poolId, address recipient) external onlyRiskManager {
+        protocolRiskPools[poolId].feeRecipient = recipient;
     }
 
     /* ───────────────────── View Functions ───────────────────── */
@@ -122,7 +122,7 @@ contract PoolRegistry is IPoolRegistry, Ownable {
         return protocolRiskPools.length;
     }
 
-    function getPoolData(uint256 _poolId) external view override returns (
+    function getPoolData(uint256 poolId) external view override returns (
         IERC20 protocolTokenToCover,
         uint256 totalCapitalPledgedToPool,
         uint256 totalCoverageSold,
@@ -131,7 +131,7 @@ contract PoolRegistry is IPoolRegistry, Ownable {
         address feeRecipient,
         uint256 claimFeeBps
     ) {
-        PoolData storage pool = protocolRiskPools[_poolId];
+        PoolData storage pool = protocolRiskPools[poolId];
         return (
             pool.protocolTokenToCover,
             pool.totalCapitalPledgedToPool,
@@ -146,15 +146,15 @@ contract PoolRegistry is IPoolRegistry, Ownable {
 
     /**
     * @notice Gets the data for multiple pools in a single call.
-    * @param _poolIds An array of IDs for the pools to query.
+    * @param poolIds An array of IDs for the pools to query.
     * @return A memory array of PoolInfo structs containing the data for each requested pool.
     */
-    function getMultiplePoolData(uint256[] calldata _poolIds) external view returns (IPoolRegistry.PoolInfo[] memory) {
-        uint256 numPools = _poolIds.length;
+    function getMultiplePoolData(uint256[] calldata poolIds) external view returns (IPoolRegistry.PoolInfo[] memory) {
+        uint256 numPools = poolIds.length;
         IPoolRegistry.PoolInfo[] memory multiplePoolData = new IPoolRegistry.PoolInfo[](numPools);
 
         for (uint256 i = 0; i < numPools; i++) {
-            uint256 poolId = _poolIds[i];
+            uint256 poolId = poolIds[i];
             PoolData storage pool = protocolRiskPools[poolId];
 
             multiplePoolData[i] = IPoolRegistry.PoolInfo({
@@ -171,23 +171,23 @@ contract PoolRegistry is IPoolRegistry, Ownable {
         return multiplePoolData;
     }
     
-    function getPoolRateModel(uint256 _poolId) external view override returns (RateModel memory) {
-        return protocolRiskPools[_poolId].rateModel;
+    function getPoolRateModel(uint256 poolId) external view override returns (RateModel memory) {
+        return protocolRiskPools[poolId].rateModel;
     }
     
-    function getPoolActiveAdapters(uint256 _poolId) external view override returns (address[] memory) {
-        return protocolRiskPools[_poolId].activeAdapters;
+    function getPoolActiveAdapters(uint256 poolId) external view override returns (address[] memory) {
+        return protocolRiskPools[poolId].activeAdapters;
     }
 
-    function getCapitalPerAdapter(uint256 _poolId, address _adapter) external view override returns (uint256) {
-        return protocolRiskPools[_poolId].capitalPerAdapter[_adapter];
+    function getCapitalPerAdapter(uint256 poolId, address adapter) external view override returns (uint256) {
+        return protocolRiskPools[poolId].capitalPerAdapter[adapter];
     }
     
     /**
      * @notice CORRECTED: This function is now implemented to serve the on-chain needs of the RiskManager.
      */
-    function getPoolPayoutData(uint256 _poolId) external view override returns (address[] memory, uint256[] memory, uint256) {
-        PoolData storage pool = protocolRiskPools[_poolId];
+    function getPoolPayoutData(uint256 poolId) external view override returns (address[] memory, uint256[] memory, uint256) {
+        PoolData storage pool = protocolRiskPools[poolId];
         address[] memory adapters = pool.activeAdapters;
         uint256[] memory capitalPerAdapter = new uint256[](adapters.length);
         for(uint i = 0; i < adapters.length; i++){
@@ -197,16 +197,16 @@ contract PoolRegistry is IPoolRegistry, Ownable {
     }
 
 
-    function getPoolTokens(uint256[] calldata _poolIds)
+    function getPoolTokens(uint256[] calldata poolIds)
         external
         view
         returns (address[] memory tokens)
     {
-        uint256 len = _poolIds.length;
+        uint256 len = poolIds.length;
         tokens = new address[](len);
 
         for (uint256 i = 0; i < len; i++) {
-            uint256 pid = _poolIds[i];
+            uint256 pid = poolIds[i];
             require(pid < protocolRiskPools.length, "PR: Invalid poolId");
             tokens[i] = address(protocolRiskPools[pid].protocolTokenToCover);
         }

--- a/contracts/interfaces/IPoolRegistry.sol
+++ b/contracts/interfaces/IPoolRegistry.sol
@@ -23,7 +23,7 @@ interface IPoolRegistry {
 
     enum ProtocolRiskIdentifier { NONE, PROTOCOL_A, PROTOCOL_B, LIDO_STETH, ROCKET_RETH }
 
-    function getPoolData(uint256 _poolId) external view returns (
+    function getPoolData(uint256 poolId) external view returns (
         IERC20 protocolTokenToCover,
         uint256 totalCapitalPledgedToPool,
         uint256 totalCoverageSold,
@@ -33,16 +33,16 @@ interface IPoolRegistry {
         uint256 claimFeeBps
     );
 
-    function getPoolRateModel(uint256 _poolId) external view returns (RateModel memory);
-    function getPoolPayoutData(uint256 _poolId) external view returns (address[] memory, uint256[] memory, uint256);
-    function getPoolActiveAdapters(uint256 _poolId) external view returns (address[] memory);
-    function getCapitalPerAdapter(uint256 _poolId, address _adapter) external view returns (uint256);
+    function getPoolRateModel(uint256 poolId) external view returns (RateModel memory);
+    function getPoolPayoutData(uint256 poolId) external view returns (address[] memory, uint256[] memory, uint256);
+    function getPoolActiveAdapters(uint256 poolId) external view returns (address[] memory);
+    function getCapitalPerAdapter(uint256 poolId, address adapter) external view returns (uint256);
     function addProtocolRiskPool(address, RateModel calldata, uint256) external returns (uint256);
     function updateCapitalAllocation(uint256 poolId, address adapterAddress, uint256 pledgeAmount, bool isAllocation) external;
     function updateCapitalPendingWithdrawal(uint256 poolId, uint256 amount, bool isRequest) external;
     function updateCoverageSold(uint256 poolId, uint256 amount, bool isSale) external;
     function getPoolCount() external view returns (uint256);
-    function setPauseState(uint256 _poolId, bool _isPaused) external;
-    function setFeeRecipient(uint256 _poolId, address _recipient) external;
-    function getMultiplePoolData(uint256[] calldata _poolIds) external view returns (PoolInfo[] memory);
+    function setPauseState(uint256 poolId, bool isPaused) external;
+    function setFeeRecipient(uint256 poolId, address recipient) external;
+    function getMultiplePoolData(uint256[] calldata poolIds) external view returns (PoolInfo[] memory);
 }


### PR DESCRIPTION
## Summary
- standardize PoolRegistry function parameters to camelCase
- update interface with the same names

## Testing
- `npx hardhat test` *(fails: PolicyNFT: PolicyManager address cannot be zero)*

------
https://chatgpt.com/codex/tasks/task_e_687374228f94832eb4090fc491229dd1