### PR TITLE
Add admin wrappers to ProtocolConfigurator

### DIFF
--- a/contracts/core/ProtocolConfigurator.sol
+++ b/contracts/core/ProtocolConfigurator.sol
@@ -22,6 +22,32 @@ interface IPoolRegistry {
     function setFeeRecipient(uint256 poolId, address recipient) external;
 }
 
+interface IPoolRegistryAdmin {
+    function setRiskManager(address newRiskManager) external;
+}
+
+interface ICapitalPoolAdmin {
+    enum YieldPlatform { NONE, AAVE, COMPOUND, OTHER_YIELD }
+    function setRiskManager(address _riskManager) external;
+    function setUnderwriterNoticePeriod(uint256 _newPeriod) external;
+    function setBaseYieldAdapter(YieldPlatform _platform, address _adapterAddress) external;
+}
+
+interface IUnderwriterManagerAdmin {
+    function setMaxAllocationsPerUnderwriter(uint256 _newMax) external;
+    function setDeallocationNoticePeriod(uint256 _newPeriod) external;
+}
+
+interface IPolicyManagerAdmin {
+    function setCatPool(address catPoolAddress) external;
+    function setCatPremiumShareBps(uint256 newBps) external;
+    function setCoverCooldownPeriod(uint256 newPeriod) external;
+}
+
+interface IRiskManagerAdmin {
+    function setCommittee(address _newCommittee) external;
+}
+
 /**
  * @title RiskAdmin
  * @author Gemini
@@ -34,9 +60,14 @@ contract RiskAdmin is Ownable {
     /* ───────────────────────── State Variables ───────────────────────── */
     IPoolRegistry public poolRegistry;
     address public committee;
+    address public capitalPool;
+    address public policyManager;
+    address public underwriterManager;
+    address public riskManager;
 
     /* ───────────────────────── Events ───────────────────────── */
     event AddressesSet(address registry);
+    event CoreContractsSet(address capitalPool, address policyManager, address underwriterManager, address riskManager);
     event CommitteeSet(address indexed newCommittee);
     event PoolAdded(uint256 indexed poolId, address indexed protocolToken);
     event IncidentReported(uint256 indexed poolId, bool isPaused);
@@ -49,6 +80,25 @@ contract RiskAdmin is Ownable {
     /* ───────────────────── Constructor & Setup ───────────────────── */
 
     constructor(address _initialOwner) Ownable(_initialOwner) {}
+
+    function setCoreContracts(
+        address _capitalPool,
+        address _policyManager,
+        address _underwriterManager,
+        address _riskManager
+    ) external onlyOwner {
+        if (
+            _capitalPool == address(0) ||
+            _policyManager == address(0) ||
+            _underwriterManager == address(0) ||
+            _riskManager == address(0)
+        ) revert ZeroAddressNotAllowed();
+        capitalPool = _capitalPool;
+        policyManager = _policyManager;
+        underwriterManager = _underwriterManager;
+        riskManager = _riskManager;
+        emit CoreContractsSet(_capitalPool, _policyManager, _underwriterManager, _riskManager);
+    }
 
     /**
      * @notice Sets the address of the PoolRegistry contract.
@@ -88,6 +138,46 @@ contract RiskAdmin is Ownable {
         uint256 poolId = poolRegistry.addProtocolRiskPool(protocolTokenToCover, rateModel, claimFeeBps);
         emit PoolAdded(poolId, protocolTokenToCover);
         return poolId;
+    }
+
+    function setPoolRegistryRiskManager(address newRiskManager) external onlyOwner {
+        IPoolRegistryAdmin(address(poolRegistry)).setRiskManager(newRiskManager);
+    }
+
+    function setCapitalPoolRiskManager(address newRiskManager) external onlyOwner {
+        ICapitalPoolAdmin(capitalPool).setRiskManager(newRiskManager);
+    }
+
+    function setCapitalPoolNoticePeriod(uint256 newPeriod) external onlyOwner {
+        ICapitalPoolAdmin(capitalPool).setUnderwriterNoticePeriod(newPeriod);
+    }
+
+    function setCapitalPoolBaseYieldAdapter(ICapitalPoolAdmin.YieldPlatform platform, address adapter) external onlyOwner {
+        ICapitalPoolAdmin(capitalPool).setBaseYieldAdapter(platform, adapter);
+    }
+
+    function setUnderwriterMaxAllocations(uint256 newMax) external onlyOwner {
+        IUnderwriterManagerAdmin(underwriterManager).setMaxAllocationsPerUnderwriter(newMax);
+    }
+
+    function setUnderwriterDeallocationNotice(uint256 newPeriod) external onlyOwner {
+        IUnderwriterManagerAdmin(underwriterManager).setDeallocationNoticePeriod(newPeriod);
+    }
+
+    function setPolicyCatPool(address catPoolAddress) external onlyOwner {
+        IPolicyManagerAdmin(policyManager).setCatPool(catPoolAddress);
+    }
+
+    function setPolicyCatPremiumShare(uint256 newBps) external onlyOwner {
+        IPolicyManagerAdmin(policyManager).setCatPremiumShareBps(newBps);
+    }
+
+    function setPolicyCoverCooldown(uint256 newPeriod) external onlyOwner {
+        IPolicyManagerAdmin(policyManager).setCoverCooldownPeriod(newPeriod);
+    }
+
+    function setRiskManagerCommittee(address newCommittee) external onlyOwner {
+        IRiskManagerAdmin(riskManager).setCommittee(newCommittee);
     }
 
     /* ───────────────────── Committee Hooks ───────────────────── */


### PR DESCRIPTION
## Summary
- extend `ProtocolConfigurator` (RiskAdmin) with references to core contracts
- expose wrappers to call admin setters on key modules

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: HH701 due to duplicate RiskManager artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6874d59e73e8832e9c710934f0370d26