### PR TITLE
Integrate ProtocolConfigurator deployment

### DIFF
--- a/scripts/deploy-usdc.js
+++ b/scripts/deploy-usdc.js
@@ -114,6 +114,17 @@ async function main() {
     riskManager.target
   );
 
+  /*───────────────────────── ProtocolConfigurator ───────────────────────*/
+  const ProtocolConfigurator = await ethers.getContractFactory("RiskAdmin");
+  const protocolConfigurator = await ProtocolConfigurator.deploy(deployer.address);
+  await protocolConfigurator.waitForDeployment();
+  await protocolConfigurator.initialize(
+    poolRegistry.target,
+    capitalPool.target,
+    policyManager.target,
+    underwriterManager.target
+  );
+
   /*─────────────────────────── Yield adapters ────────────────────────────*/
   // 1. Aave v3
   const AaveAdapter = await ethers.getContractFactory("AaveV3Adapter");
@@ -154,6 +165,7 @@ async function main() {
     LossDistributor:   lossDistributor.target,
     RewardDistributor: rewardDistributor.target,
     RiskManager:       riskManager.target,
+    ProtocolConfigurator: protocolConfigurator.target,
     UnderwriterManager: underwriterManager.target,
     "Aave Adapter":    aaveAdapter.target,
     "Compound Adapter": compoundAdapter.target,

--- a/scripts/deploy-weth.js
+++ b/scripts/deploy-weth.js
@@ -104,6 +104,17 @@ async function main() {
     riskManager.target
   );
 
+  /*───────────────────────── ProtocolConfigurator ───────────────────────*/
+  const ProtocolConfigurator = await ethers.getContractFactory("RiskAdmin");
+  const protocolConfigurator = await ProtocolConfigurator.deploy(deployer.address);
+  await protocolConfigurator.waitForDeployment();
+  await protocolConfigurator.initialize(
+    poolRegistry.target,
+    capitalPool.target,
+    policyManager.target,
+    underwriterManager.target
+  );
+
   /*─────────────────────────── Yield adapters ────────────────────────────*/
   // 1. Aave v3
   const AaveAdapter = await ethers.getContractFactory("AaveV3Adapter");
@@ -140,6 +151,7 @@ async function main() {
     LossDistributor:   lossDistributor.target,
     RewardDistributor: rewardDistributor.target,
     RiskManager:       riskManager.target,
+    ProtocolConfigurator: protocolConfigurator.target,
     UnderwriterManager: underwriterManager.target,
     "Aave Adapter":    aaveAdapter.target,
     "Compound Adapter": compoundAdapter.target,


### PR DESCRIPTION
## Summary
- add deployment steps for `ProtocolConfigurator` (RiskAdmin) in USDC and WETH deploy scripts
- record the new address in the output JSON

## Testing
- `npm test` *(fails: PolicyNFT PolicyManager address cannot be zero)*

------
https://chatgpt.com/codex/tasks/task_e_6874e2c44050832e800122f57f4058a2