### PR TITLE
Refactor contracts to use interface imports

### DIFF
--- a/contracts/core/ProtocolConfigurator.sol
+++ b/contracts/core/ProtocolConfigurator.sol
@@ -4,49 +4,12 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 // --- Interfaces ---
-
-interface IPoolRegistry {
-    struct RateModel {
-        uint128 U_1;
-        uint128 U_2;
-        uint128 R_0;
-        uint128 R_1;
-        uint128 R_2;
-    }
-    function addProtocolRiskPool(
-        address protocolTokenToCover,
-        RateModel calldata rateModel,
-        uint256 claimFeeBps
-    ) external returns (uint256);
-    function setPauseState(uint256 poolId, bool pauseState) external;
-    function setFeeRecipient(uint256 poolId, address recipient) external;
-}
-
-interface IPoolRegistryAdmin {
-    function setRiskManager(address newRiskManager) external;
-}
-
-interface ICapitalPoolAdmin {
-    enum YieldPlatform { NONE, AAVE, COMPOUND, OTHER_YIELD }
-    function setRiskManager(address _riskManager) external;
-    function setUnderwriterNoticePeriod(uint256 _newPeriod) external;
-    function setBaseYieldAdapter(YieldPlatform _platform, address _adapterAddress) external;
-}
-
-interface IUnderwriterManagerAdmin {
-    function setMaxAllocationsPerUnderwriter(uint256 _newMax) external;
-    function setDeallocationNoticePeriod(uint256 _newPeriod) external;
-}
-
-interface IPolicyManagerAdmin {
-    function setCatPool(address catPoolAddress) external;
-    function setCatPremiumShareBps(uint256 newBps) external;
-    function setCoverCooldownPeriod(uint256 newPeriod) external;
-}
-
-interface IRiskManagerAdmin {
-    function setCommittee(address _newCommittee) external;
-}
+import {IPoolRegistry} from "../interfaces/IPoolRegistry.sol";
+import {IPoolRegistryAdmin} from "../interfaces/IPoolRegistryAdmin.sol";
+import {ICapitalPoolAdmin} from "../interfaces/ICapitalPoolAdmin.sol";
+import {IUnderwriterManagerAdmin} from "../interfaces/IUnderwriterManagerAdmin.sol";
+import {IPolicyManagerAdmin} from "../interfaces/IPolicyManagerAdmin.sol";
+import {IRiskManagerAdmin} from "../interfaces/IRiskManagerAdmin.sol";
 
 /**
  * @title RiskAdmin
@@ -56,7 +19,6 @@ interface IRiskManagerAdmin {
  * Its purpose is to manage system-level parameters and critical safety features.
  */
 contract RiskAdmin is Ownable {
-
     /* ───────────────────────── State Variables ───────────────────────── */
     IPoolRegistry public poolRegistry;
     address public committee;
@@ -91,18 +53,14 @@ contract RiskAdmin is Ownable {
      * @notice Initializes the core contract addresses. Can only be called once by the owner.
      * @dev This approach ensures that all critical addresses are set in a single, atomic transaction.
      */
-    function initialize(
-        address _registry,
-        address _capitalPool,
-        address _policyManager,
-        address _underwriterManager
-    ) external onlyOwner {
+    function initialize(address _registry, address _capitalPool, address _policyManager, address _underwriterManager)
+        external
+        onlyOwner
+    {
         if (address(poolRegistry) != address(0)) revert AlreadyInitialized();
         if (
-            _registry == address(0) ||
-            _capitalPool == address(0) ||
-            _policyManager == address(0) ||
-            _underwriterManager == address(0)
+            _registry == address(0) || _capitalPool == address(0) || _policyManager == address(0)
+                || _underwriterManager == address(0)
         ) revert ZeroAddressNotAllowed();
 
         poolRegistry = IPoolRegistry(_registry);
@@ -153,7 +111,11 @@ contract RiskAdmin is Ownable {
         ICapitalPoolAdmin(capitalPool).setUnderwriterNoticePeriod(newPeriod);
     }
 
-    function setCapitalPoolBaseYieldAdapter(ICapitalPoolAdmin.YieldPlatform platform, address adapter) external onlyOwner initialized {
+    function setCapitalPoolBaseYieldAdapter(ICapitalPoolAdmin.YieldPlatform platform, address adapter)
+        external
+        onlyOwner
+        initialized
+    {
         ICapitalPoolAdmin(capitalPool).setBaseYieldAdapter(platform, adapter);
     }
 

--- a/contracts/interfaces/ICapitalPoolAdmin.sol
+++ b/contracts/interfaces/ICapitalPoolAdmin.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface ICapitalPoolAdmin {
+    enum YieldPlatform {
+        NONE,
+        AAVE,
+        COMPOUND,
+        OTHER_YIELD
+    }
+
+    function setRiskManager(address _riskManager) external;
+    function setUnderwriterNoticePeriod(uint256 _newPeriod) external;
+    function setBaseYieldAdapter(YieldPlatform _platform, address _adapterAddress) external;
+}

--- a/contracts/interfaces/IPolicyManagerAdmin.sol
+++ b/contracts/interfaces/IPolicyManagerAdmin.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IPolicyManagerAdmin {
+    function setCatPool(address catPoolAddress) external;
+    function setCatPremiumShareBps(uint256 newBps) external;
+    function setCoverCooldownPeriod(uint256 newPeriod) external;
+}

--- a/contracts/interfaces/IPoolRegistryAdmin.sol
+++ b/contracts/interfaces/IPoolRegistryAdmin.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IPoolRegistryAdmin {
+    function setRiskManager(address newRiskManager) external;
+}

--- a/contracts/interfaces/IRiskManagerAdmin.sol
+++ b/contracts/interfaces/IRiskManagerAdmin.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IRiskManagerAdmin {
+    function setCommittee(address _newCommittee) external;
+}

--- a/contracts/interfaces/IUnderwriterManager.sol
+++ b/contracts/interfaces/IUnderwriterManager.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IUnderwriterManager {
+    function getUnderwriterAllocations(address user) external view returns (uint256[] memory);
+    function underwriterPoolPledge(address user, uint256 poolId) external view returns (uint256);
+    function realizeLossesForAllPools(address user) external;
+}

--- a/contracts/interfaces/IUnderwriterManagerAdmin.sol
+++ b/contracts/interfaces/IUnderwriterManagerAdmin.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+interface IUnderwriterManagerAdmin {
+    function setMaxAllocationsPerUnderwriter(uint256 _newMax) external;
+    function setDeallocationNoticePeriod(uint256 _newPeriod) external;
+}

--- a/foundry/test/RiskManager.t.sol
+++ b/foundry/test/RiskManager.t.sol
@@ -8,7 +8,14 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {RiskManager} from "contracts/core/RiskManager.sol";
 
 // --- Interfaces (as defined in the contract file) ---
-import {ICapitalPool, IPolicyNFT, IPoolRegistry, IBackstopPool, ILossDistributor, IRewardDistributor, IUnderwriterManager, IPolicyManager} from "contracts/core/RiskManager.sol";
+import {ICapitalPool} from "contracts/interfaces/ICapitalPool.sol";
+import {IPolicyNFT} from "contracts/interfaces/IPolicyNFT.sol";
+import {IPoolRegistry} from "contracts/interfaces/IPoolRegistry.sol";
+import {IBackstopPool} from "contracts/interfaces/IBackstopPool.sol";
+import {ILossDistributor} from "contracts/interfaces/ILossDistributor.sol";
+import {IRewardDistributor} from "contracts/interfaces/IRewardDistributor.sol";
+import {IUnderwriterManager} from "contracts/interfaces/IUnderwriterManager.sol";
+import {IPolicyManager} from "contracts/interfaces/IPolicyManager.sol";
 
 // --- Mocks ---
 import {MockERC20} from "./mocks/MockERC20.sol";
@@ -120,7 +127,8 @@ contract RiskManagerTest is Test {
         assertEq(payoutData.feeAmount, expectedFee);
 
         // 4. PoolRegistry state updates
-        (uint256 lastUpdatePoolId, , uint256 lastUpdateAmount, bool lastIsAllocation) = pr.get_last_updateCapitalAllocation();
+        (uint256 lastUpdatePoolId,, uint256 lastUpdateAmount, bool lastIsAllocation) =
+            pr.get_last_updateCapitalAllocation();
         assertEq(lastUpdatePoolId, poolId);
         assertEq(lastUpdateAmount, coverage);
         assertFalse(lastIsAllocation);
@@ -154,7 +162,6 @@ contract RiskManagerTest is Test {
         assertEq(cat.drawFundCallCount(), 1, "BackstopPool.drawFund should be called");
         assertEq(cat.last_drawFund_amount(), expectedShortfall, "Incorrect shortfall amount drawn");
     }
-
 
     function test_liquidateInsolventUnderwriter_succeeds() public {
         // --- Arrange ---


### PR DESCRIPTION
## Summary
- add interface files for admin contracts and UnderwriterManager
- remove inline interface definitions in core contracts
- update RiskManager test to import interfaces from `contracts/interfaces`

## Testing
- `forge build` *(fails: Source `foundry/test/mocks/MockERC20.sol` not found)*
- `npx hardhat test` *(fails: PolicyNFT: PolicyManager address cannot be zero)*

------
https://chatgpt.com/codex/tasks/task_e_6874e3dc9c5c832eaf42199d14920b03