### PR TITLE
Fix Backstop and RiskManager tests

### DIFF
--- a/foundry/test/RiskManager.t.sol
+++ b/foundry/test/RiskManager.t.sol
@@ -423,8 +423,19 @@ contract RiskManagerComprehensiveTest is Test {
         address policyOwner,
         uint256 activationTimestamp
     ) internal {
-        nft.setPolicy(policyId, poolId, coverage, activationTimestamp);
-        nft.setOwnerOf(policyId, policyOwner);
+        // Use the flexible helper that allows setting all policy fields so
+        // tests can control the activation timestamp. The mock function also
+        // assigns the owner, so a separate `setOwnerOf` call is unnecessary.
+        nft.mock_setPolicy(
+            policyId,
+            policyOwner,
+            poolId,
+            coverage,
+            activationTimestamp, // start
+            activationTimestamp, // activation
+            0,
+            0
+        );
     }
 
     function _setupPool(


### PR DESCRIPTION
## Summary
- handle adapter reverts in invariant
- grant dedicated owner address for BackstopPool tests and prank when needed
- set policy activation correctly in RiskManager test helper

## Testing
- `forge test --match-contract BackstopPoolComprehensiveTest -vv`
- `forge test -vv`


------
https://chatgpt.com/codex/tasks/task_e_6876820b5c24832eb8d9d9c80738657c