### PR TITLE
Delegate setup to ProtocolConfigurator

### DIFF
--- a/scripts/deploy-governance.js
+++ b/scripts/deploy-governance.js
@@ -15,8 +15,9 @@ const { ethers } = hre;
 const fs = require("fs");
 const path = require("path");
 
-// TODO: set this to the deployed RiskManager address
+// TODO: set these to the deployed addresses
 const RISK_MANAGER_ADDRESS = "0xD1c640f4C9ff53ba46B42959ECB9a76f2dB9Cb2b";
+const PROTOCOL_CONFIGURATOR_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const VOTING_PERIOD = 7 * 24 * 60 * 60;       // 7 days
 const CHALLENGE_PERIOD = 7 * 24 * 60 * 60;    // 7 days
@@ -32,6 +33,10 @@ async function main() {
   const riskManager = await ethers.getContractAt(
     "RiskManager",
     RISK_MANAGER_ADDRESS
+  );
+  const protocolConfigurator = await ethers.getContractAt(
+    "RiskAdmin",
+    PROTOCOL_CONFIGURATOR_ADDRESS
   );
 
   /*───────────────────────── Governance token ─────────────────────────*/
@@ -61,7 +66,7 @@ async function main() {
 
   // Wire committee address in staking contract
   await staking.setCommitteeAddress(committee.target);
-  await riskManager.setCommittee(committee.target)
+  await protocolConfigurator.setCommittee(committee.target, RISK_MANAGER_ADDRESS);
 
   /*──────────────────────────── Output ────────────────────────────────*/
   const addresses = {

--- a/scripts/deploy-weth.js
+++ b/scripts/deploy-weth.js
@@ -78,7 +78,6 @@ async function main() {
   await capitalPool.waitForDeployment();
 
   // Wire permissions and addresses
-  await capitalPool.setRiskManager(riskManager.target);
   await catPool.setRiskManagerAddress(riskManager.target);
   await catPool.setCapitalPoolAddress(capitalPool.target);
   await catPool.setPolicyManagerAddress(policyManager.target);
@@ -115,6 +114,10 @@ async function main() {
     underwriterManager.target
   );
 
+  // Use configurator for initial setup
+  await protocolConfigurator.setPoolRegistryRiskManager(riskManager.target);
+  await protocolConfigurator.setCapitalPoolRiskManager(riskManager.target);
+
   /*─────────────────────────── Yield adapters ────────────────────────────*/
   // 1. Aave v3
   const AaveAdapter = await ethers.getContractFactory("AaveV3Adapter");
@@ -131,15 +134,24 @@ async function main() {
 
   /*──────────────── Register adapters in CapitalPool (enum indices) ──────*/
   // 1=AAVE, 2=COMPOUND
-  await capitalPool.setBaseYieldAdapter(1, aaveAdapter.target);
-  await capitalPool.setBaseYieldAdapter(2, compoundAdapter.target);
+  await protocolConfigurator.setCapitalPoolBaseYieldAdapter(1, aaveAdapter.target);
+  await protocolConfigurator.setCapitalPoolBaseYieldAdapter(2, compoundAdapter.target);
 
   /*────────────────────── Protocol risk‑pool examples ───────────────────*/
   const defaultRateModel = { base: 200, slope1: 1000, slope2: 5000, kink: 7000 };
 
   // WETH pools across both platforms
-  await riskManager.addProtocolRiskPool(WETH_ADDRESS, defaultRateModel, 1);
-  await riskManager.addProtocolRiskPool(WETH_ADDRESS, defaultRateModel, 2);
+  await protocolConfigurator.addProtocolRiskPool(WETH_ADDRESS, defaultRateModel, 1);
+  await protocolConfigurator.addProtocolRiskPool(WETH_ADDRESS, defaultRateModel, 2);
+
+  // Transfer ownership of core contracts to the configurator
+  await poolRegistry.transferOwnership(protocolConfigurator.target);
+  await capitalPool.transferOwnership(protocolConfigurator.target);
+  await policyManager.transferOwnership(protocolConfigurator.target);
+  await riskManager.transferOwnership(protocolConfigurator.target);
+  await underwriterManager.transferOwnership(protocolConfigurator.target);
+  await rewardDistributor.transferOwnership(protocolConfigurator.target);
+  await catPool.transferOwnership(protocolConfigurator.target);
 
   /*──────────────────────────────── Output ──────────────────────────────*/
   const addresses = {


### PR DESCRIPTION
## Summary
- wire up ProtocolConfigurator in USDC and WETH deployment scripts
- let the configurator own and configure deployed contracts
- adjust governance deploy script to call configurator

## Testing
- `npx hardhat test` *(fails: PolicyNFT: PolicyManager address cannot be zero)*

------
https://chatgpt.com/codex/tasks/task_e_68768e69ff98832ea1a8698107e5ba95