### PR TITLE
Fix committee tests

### DIFF
--- a/contracts/governance/Committee.sol
+++ b/contracts/governance/Committee.sol
@@ -316,16 +316,15 @@ contract Committee is Ownable, ReentrancyGuard {
     function _calculateUserReward(uint256 proposalId, address claimant) internal view returns (uint256) {
         Proposal storage p = proposals[proposalId];
         uint256 totalFees = p.totalRewardFees;
-        uint256 proposerBonus = 0;
-        
-        if (claimant == p.proposer) {
-            proposerBonus = (totalFees * p.proposerFeeShareBps) / 10000;
-        }
-        
+        uint256 proposerBonus = (totalFees * p.proposerFeeShareBps) / 10000;
         uint256 remainingFees = totalFees - proposerBonus;
         uint256 userWeight = p.voterWeight[claimant];
-        
-        return proposerBonus + (remainingFees * userWeight) / p.forVotes;
+
+        uint256 reward = (remainingFees * userWeight) / p.forVotes;
+        if (claimant == p.proposer) {
+            reward += proposerBonus;
+        }
+        return reward;
     }
 
     function _calculateFeeShare(uint256 _bondAmount) internal pure returns (uint256) {


### PR DESCRIPTION
## Summary
- adjust tests to handle cheatcodes correctly
- fix quorum/slashing assertions
- correct reward calculation in `Committee`

## Testing
- `forge test --match-path foundry/test/Committee.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_6876bbf01108832ea19912c24f833ae0