### PR TITLE
Fix missing cat pool address

### DIFF
--- a/frontend/app/config/deployments.js
+++ b/frontend/app/config/deployments.js
@@ -11,7 +11,7 @@ try {
     underwriterManager: item.UnderwriterManager || item.RiskManager,
     protocolConfigurator: item.ProtocolConfigurator || item.RiskManager,
     capitalPool: item.CapitalPool,
-    backstopPool: item.CatInsurancePool,
+    backstopPool: item.CatInsurancePool || item.BackstopPool,
     poolRegistry: item.PoolRegistry,
     policyManager: item.PolicyManager,
     priceOracle: item.PriceOracle,


### PR DESCRIPTION
## Summary
- support both `BackstopPool` and `CatInsurancePool` keys in deployment config

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6877ac8377d8832eb3e9f0926bf46174