### PR TITLE
Fix mock contract compilation

### DIFF
--- a/contracts/test/MockLossDistributor.sol
+++ b/contracts/test/MockLossDistributor.sol
@@ -39,13 +39,17 @@ contract MockLossDistributor is ILossDistributor {
         emit LossDistributed(poolId, lossAmount, totalPledgeInPool);
     }
 
-    function realizeLosses(address user, uint256 poolId, uint256) external override returns (uint256) {
+    function realizeLosses(address user, uint256 poolId, uint256 userPledge) external override returns (uint256) {
+        // `userPledge` is unused in this mock but kept for interface compatibility
+        userPledge; // Silence unused variable warning
         uint256 amount = pending[user][poolId];
         pending[user][poolId] = 0;
         return amount;
     }
 
-    function getPendingLosses(address user, uint256 poolId, uint256) external view override returns (uint256) {
+    function getPendingLosses(address user, uint256 poolId, uint256 userPledge) external view override returns (uint256) {
+        // `userPledge` is unused in this mock but kept for interface compatibility
+        userPledge;
         return pending[user][poolId];
     }
 }

--- a/contracts/test/MockRiskManagerWithBackstop.sol
+++ b/contracts/test/MockRiskManagerWithBackstop.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "../interfaces/IRiskManagerWithBackstop.sol";
 import "../interfaces/IBackstopPool.sol";
 import "../core/CapitalPool.sol";
+import "../interfaces/ICapitalPool.sol";
 
 contract MockRiskManagerWithBackstop is IRiskManagerWithBackstop {
     IBackstopPool public override catPool;
@@ -37,6 +38,6 @@ contract MockRiskManagerWithBackstop is IRiskManagerWithBackstop {
     }
 
     function applyLossesOnPool(address pool, address underwriter, uint256 amount) external {
-        CapitalPool(pool).applyLosses(underwriter, amount);
+        ICapitalPool(pool).applyLosses(underwriter, amount);
     }
 }


### PR DESCRIPTION
## Summary
- adjust MockLossDistributor to support new interface arguments
- call applyLosses via ICapitalPool in MockRiskManagerWithBackstop

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_6878164d64f8832ea16c36c9ea2aac08