### PR TITLE
Read CatPool tokens from config

### DIFF
--- a/frontend/app/catpool/page.js
+++ b/frontend/app/catpool/page.js
@@ -8,15 +8,11 @@ import CatPoolModal from "../components/CatPoolModal"
 import CatPoolDeposits from "../components/CatPoolDeposits"
 import { formatCurrency } from "../utils/formatting"
 import { getTokenLogo } from "../config/tokenNameMap"
+import SUPPORTED_TOKENS from "../config/supportedTokens"
 import useCatPoolUserInfo from "../../hooks/useCatPoolUserInfo"
 import useCatPoolStats from "../../hooks/useCatPoolStats"
 import useAnalytics from "../../hooks/useAnalytics"
 
-const SUPPORTED_TOKENS = [
-  { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", name: "USD Coin" },
-  { address: "0x4200000000000000000000000000000000000006", symbol: "WETH", name: "Wrapped Ether" },
-  { address: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", symbol: "DAI", name: "Dai Stablecoin" },
-]
 
 export default function CatPoolPage() {
   const { address } = useAccount()

--- a/frontend/app/config/supportedTokens.js
+++ b/frontend/app/config/supportedTokens.js
@@ -1,0 +1,7 @@
+export const SUPPORTED_TOKENS = [
+  { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", name: "USD Coin" },
+  { address: "0x4200000000000000000000000000000000000006", symbol: "WETH", name: "Wrapped Ether" },
+  { address: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", symbol: "DAI", name: "Dai Stablecoin" },
+];
+
+export default SUPPORTED_TOKENS;


### PR DESCRIPTION
## Summary
- move CatPool supported token list to `app/config`
- import supported tokens from config in CatPool page

## Testing
- `npm run test` *(fails: failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6878ddb26928832ea5976d861af42b55