### PR TITLE
Enable chain switcher for Base networks

### DIFF
--- a/frontend/app/components/Navbar.js
+++ b/frontend/app/components/Navbar.js
@@ -8,6 +8,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit"
 import ThemeToggle from "./ThemeToggle"
 import CurrencyToggle from "./CurrencyToggle"
 import MobileNav from "./MobileNav"
+import NetworkSelector from "./NetworkSelector"
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false)
@@ -84,12 +85,14 @@ export default function Navbar() {
             >
               Transactions
             </Link>
+            <NetworkSelector />
             <ThemeToggle />
             <ConnectButton />
           </div>
 
           {/* Mobile menu button */}
           <div className="md:hidden flex items-center space-x-2">
+            <NetworkSelector />
             <ThemeToggle />
             <button
               onClick={() => setIsOpen(!isOpen)}

--- a/frontend/app/components/NetworkSelector.js
+++ b/frontend/app/components/NetworkSelector.js
@@ -1,0 +1,20 @@
+"use client";
+import { useNetwork } from '../../hooks/useNetwork';
+import { CHAINS } from '../config/chains';
+
+export default function NetworkSelector() {
+  const { chainId, switchNetwork } = useNetwork();
+  return (
+    <select
+      className="border rounded-md px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+      value={chainId}
+      onChange={(e) => switchNetwork(parseInt(e.target.value))}
+    >
+      {CHAINS.map((c) => (
+        <option key={c.id} value={c.id}>
+          {c.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/app/config.js
+++ b/frontend/app/config.js
@@ -1,7 +1,7 @@
 // app/config.js
 import { http } from 'wagmi';
-// 1. Import getDefaultConfig
 import { getDefaultConfig } from '@rainbow-me/rainbowkit';
+import { CHAINS, CHAIN_MAP } from './config/chains';
 
 // 2. Get WalletConnect Project ID from environment variables
 const projectId = process.env.NEXT_PUBLIC_WC_PROJECT_ID;
@@ -15,42 +15,21 @@ if (!projectId) {
   // For RainbowKit defaults to work best, a projectId is needed.
 }
 
-// 3. Define the Base mainnet chain
-const baseMainnet = {
-  id: 8453,
-  name: 'Base',
-  network: 'base-mainnet',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
-  },
-  rpcUrls: {
-    default: {
-      http: [
-        // Use env variable in prod, fall back to public RPC in dev
-        process.env.NEXT_PUBLIC_RPC_URL || 'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe',
-      ],
-    },
-  },
-  blockExplorers: {
-    default: {
-      name: 'BaseScan',
-      url: 'https://basescan.org',
-    },
-  },
-  testnet: false,
-};
+let defaultChainId = 8453;
+if (typeof window !== 'undefined') {
+  const stored = window.localStorage.getItem('chainId');
+  if (stored) defaultChainId = parseInt(stored, 10);
+}
 
-// 4. Use getDefaultConfig to create wagmi/RainbowKit config
 export const config = getDefaultConfig({
   appName: 'LayerCover',
   projectId: projectId || 'DEFAULT_PROJECT_ID_IF_MISSING',
-  chains: [baseMainnet],
+  chains: CHAINS,
   transports: {
-    [baseMainnet.id]: http(
-      process.env.NEXT_PUBLIC_RPC_URL || 'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe',
-    ),
+    [CHAIN_MAP[8453].id]: http(CHAIN_MAP[8453].rpcUrls.default.http[0]),
+    [CHAIN_MAP[84532].id]: http(CHAIN_MAP[84532].rpcUrls.default.http[0]),
   },
   ssr: true,
 });
+
+export { defaultChainId };

--- a/frontend/app/config/chains.js
+++ b/frontend/app/config/chains.js
@@ -1,0 +1,25 @@
+export const BASE_MAINNET = {
+  id: 8453,
+  name: 'Base',
+  network: 'base-mainnet',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: { default: { http: [process.env.NEXT_PUBLIC_RPC_URL || 'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe'] } },
+  blockExplorers: { default: { name: 'BaseScan', url: 'https://basescan.org' } },
+  testnet: false,
+};
+
+export const BASE_SEPOLIA = {
+  id: 84532,
+  name: 'Base Sepolia',
+  network: 'base-sepolia',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: { default: { http: [process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL || 'https://sepolia.base.org'] } },
+  blockExplorers: { default: { name: 'BaseScan', url: 'https://sepolia.basescan.org' } },
+  testnet: true,
+};
+
+export const CHAINS = [BASE_MAINNET, BASE_SEPOLIA];
+export const CHAIN_MAP = {
+  [BASE_MAINNET.id]: BASE_MAINNET,
+  [BASE_SEPOLIA.id]: BASE_SEPOLIA,
+};

--- a/frontend/app/config/tokenNameMap.js
+++ b/frontend/app/config/tokenNameMap.js
@@ -1,5 +1,15 @@
 import { IdCard } from "lucide-react";
 import { STAKING_TOKEN_ADDRESS } from "./deployments";
+import { CHAIN_MAP } from "./chains";
+
+let currentChainId = 8453;
+if (typeof window !== 'undefined') {
+  const stored = window.localStorage.getItem('chainId');
+  if (stored) currentChainId = parseInt(stored, 10);
+}
+export function setCurrentChainId(id) {
+  currentChainId = id;
+}
 
 export const PROTOCOL_NAME_MAP = {
   0: 'USDC',
@@ -40,26 +50,49 @@ export const UNDERLYING_TOKEN_LOGO_MAP = {
   "usdc": '/images/tokens/usdc.png',
 }
 
-export const TOKEN_NAME_MAP = {
-  "0xc6Bc407706B7140EE8Eef2f86F9504651b63e7f9": 'USDC',
-  "0x3695Dd1D1D43B794C0B13eb8be8419Eb3ac22bf7": "USDT",
-  "0x4447863cddABbF2c3dAC826f042e03c91927A196": 'USDM',
-  "0x2502F488D481Df4F5054330C71b95d93D41625C2": "DAI"
-
+const TOKEN_NAME_MAPS = {
+  8453: {
+    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": 'USDC',
+    "0x50c5725949a6f0c72e6c4a641f24049a917db0cb": 'USD+',
+    "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376": 'DAI',
+    "0x4200000000000000000000000000000000000006": 'WETH',
+  },
+  84532: {
+    "0xc6bc407706b7140ee8eef2f86f9504651b63e7f9": 'USDC',
+    "0x3695dd1d1d43b794c0b13eb8be8419eb3ac22bf7": 'USDT',
+    "0x4447863cddabbf2c3dac826f042e03c91927a196": 'USDM',
+    "0x2502f488d481df4f5054330c71b95d93d41625c2": 'DAI',
+  },
 };
 
-export const TOKEN_LOGO_MAP = {
-  "0xc6Bc407706B7140EE8Eef2f86F9504651b63e7f9": '/images/stablecoins/usdc.png',
-  "0x2502F488D481Df4F5054330C71b95d93D41625C2": '/images/stablecoins/dai.svg',
-  "0x3695Dd1D1D43B794C0B13eb8be8419Eb3ac22bf7": '/images/stablecoins/usdt.png',
-  "0x4447863cddABbF2c3dAC826f042e03c91927A196": '/images/stablecoins/usdm.png'
-
+const TOKEN_LOGO_MAPS = {
+  8453: {
+    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": '/images/tokens/usdc.png',
+    "0x50c5725949a6f0c72e6c4a641f24049a917db0cb": '/images/stablecoins/usd_plus.svg',
+    "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376": '/images/stablecoins/dai.svg',
+    "0x4200000000000000000000000000000000000006": '/images/tokens/eth.png',
+  },
+  84532: {
+    "0xc6bc407706b7140ee8eef2f86f9504651b63e7f9": '/images/stablecoins/usdc.png',
+    "0x2502f488d481df4f5054330c71b95d93d41625c2": '/images/stablecoins/dai.svg',
+    "0x3695dd1d1d43b794c0b13eb8be8419eb3ac22bf7": '/images/stablecoins/usdt.png',
+    "0x4447863cddabbf2c3dac826f042e03c91927a196": '/images/stablecoins/usdm.png',
+  },
 };
 
+function currentNameMap() {
+  return TOKEN_NAME_MAPS[currentChainId] || {};
+}
+
+function currentLogoMap() {
+  return TOKEN_LOGO_MAPS[currentChainId] || {};
+}
 
 if (STAKING_TOKEN_ADDRESS) {
-  TOKEN_NAME_MAP[STAKING_TOKEN_ADDRESS] = 'Staking Token';
-  TOKEN_LOGO_MAP[STAKING_TOKEN_ADDRESS] = '/images/tokens/placeholder-token.svg';
+  const map = currentNameMap();
+  const logos = currentLogoMap();
+  map[STAKING_TOKEN_ADDRESS.toLowerCase()] = 'Staking Token';
+  logos[STAKING_TOKEN_ADDRESS.toLowerCase()] = '/images/tokens/placeholder-token.svg';
 }
 
 export function getProtocolType(id) {
@@ -69,7 +102,8 @@ export function getProtocolType(id) {
 export function getTokenName(id) {
   if (!id) return id;
   const key = typeof id === "string" ? id : `${id}`;
-  return TOKEN_NAME_MAP[key] || TOKEN_NAME_MAP[key.toLowerCase()] || id;
+  const map = currentNameMap();
+  return map[key] || map[key.toLowerCase()] || id;
 }
 
 
@@ -88,11 +122,8 @@ export function getUnderlyingTokenLogo(id) {
 export function getTokenLogo(id) {
   if (!id) return "/placeholder-logo.png";
   const key = typeof id === "string" ? id : `${id}`;
-  return (
-    TOKEN_LOGO_MAP[key] ||
-    TOKEN_LOGO_MAP[key.toLowerCase()] ||
-    "/placeholder-logo.png"
-  );
+  const map = currentLogoMap();
+  return map[key] || map[key.toLowerCase()] || "/placeholder-logo.png";
 }
 
 

--- a/frontend/app/providers.jsx
+++ b/frontend/app/providers.jsx
@@ -3,8 +3,9 @@
 
 import React from 'react';
 import { WagmiProvider } from 'wagmi';
-import { config } from './config'; // Uses the updated config
+import { config } from './config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { NetworkProvider } from '../hooks/useNetwork';
 
 // 1. Import RainbowKitProvider and styles
 import { RainbowKitProvider } from '@rainbow-me/rainbowkit';
@@ -22,12 +23,14 @@ export function Providers({ children }) {
    const [queryClient] = React.useState(() => new QueryClient());
 
   return (
-    <WagmiProvider config={config}>
-      <QueryClientProvider client={queryClient}>
-        {/* 2. Wrap with RainbowKitProvider */}
-        <RainbowKitProvider>{children}</RainbowKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <NetworkProvider>
+      <WagmiProvider config={config}>
+        <QueryClientProvider client={queryClient}>
+          {/* 2. Wrap with RainbowKitProvider */}
+          <RainbowKitProvider>{children}</RainbowKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </NetworkProvider>
   );
 }
 

--- a/frontend/hooks/useNetwork.js
+++ b/frontend/hooks/useNetwork.js
@@ -1,0 +1,40 @@
+"use client";
+import { createContext, useContext, useState, useEffect } from 'react';
+import { CHAIN_MAP } from '../app/config/chains';
+import { setCurrentChainId as setTokenChain } from '../app/config/tokenNameMap';
+import { setCurrentChainId as setProviderChain } from '../lib/provider';
+
+const NetworkContext = createContext({ chainId: 8453, switchNetwork: () => {} });
+
+export function NetworkProvider({ children }) {
+  const [chainId, setChainId] = useState(8453);
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' && window.localStorage.getItem('chainId');
+    if (stored) {
+      const id = parseInt(stored, 10);
+      setChainId(id);
+      setTokenChain(id);
+      setProviderChain(id);
+    }
+  }, []);
+
+  const switchNetwork = (id) => {
+    setChainId(id);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('chainId', id.toString());
+    }
+    setTokenChain(id);
+    setProviderChain(id);
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <NetworkContext.Provider value={{ chainId, switchNetwork, chain: CHAIN_MAP[chainId] }}>
+      {children}
+    </NetworkContext.Provider>
+  );
+}
+
+export const useNetwork = () => useContext(NetworkContext);

--- a/frontend/lib/provider.ts
+++ b/frontend/lib/provider.ts
@@ -1,20 +1,34 @@
 import { ethers } from 'ethers';
 import deployments from '../app/config/deployments';
+import { CHAIN_MAP } from '../app/config/chains';
 
-const DEFAULT_RPC_URL =
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  process.env.RPC_URL ??
-  'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe';
+let currentChainId = 8453;
+if (typeof window !== 'undefined') {
+  const stored = window.localStorage.getItem('chainId');
+  if (stored) currentChainId = parseInt(stored, 10);
+}
 
-const DEFAULT_CHAIN_ID = 8453;
+export function setCurrentChainId(id: number) {
+  currentChainId = id;
+}
+
+function getRpcUrl() {
+  const chain = CHAIN_MAP[currentChainId];
+  return (
+    chain?.rpcUrls?.default?.http[0] ||
+    process.env.NEXT_PUBLIC_RPC_URL ||
+    process.env.RPC_URL ||
+    'https://base-mainnet.g.alchemy.com/v2/1aCtyoTdLMNn0TDAz_2hqBKwJhiKBzIe'
+  );
+}
 
 /**
  * Return a StaticJsonRpcProvider for the given deployment name. If the
  * deployment is not found, fall back to the default RPC URL and chain ID.
  */
 export function getProvider(deploymentName?: string) {
-  let rpcUrl = DEFAULT_RPC_URL;
-  let chainId = DEFAULT_CHAIN_ID;
+  let rpcUrl = getRpcUrl();
+  let chainId = currentChainId;
 
   if (deploymentName) {
     const dep = deployments.find((d) => d.name === deploymentName);


### PR DESCRIPTION
## Summary
- add Base chain configurations
- allow network selection via context and dropdown
- adjust provider and token maps based on selected chain

## Testing
- `npm run check:frontend` *(fails: Frontend ABI files are out of sync)*
- `npm test` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_6878dcfa2d30832e9816202c175590bd