### PR TITLE
Add contract verification

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -51,9 +51,8 @@ module.exports = {
         // }
     },
     etherscan: {
-        // Your API key for Etherscan
-        // Obtain one at https://etherscan.io/
-        apiKey: "YOUR_ETHERSCAN_API_KEY" // Optional, for contract verification
+        // Your API key for Etherscan used for contract verification
+        apiKey: process.env.ETHERSCAN_API_KEY || "",
     },
     paths: {
         sources: "./contracts",


### PR DESCRIPTION
## Summary
- enable Etherscan API key from env
- add `verifyContract` helper to `deploy-usdc.js`
- verify deployed contracts in `deploy-usdc.js`
- verify governance contracts in `deploy-governance.js`

## Testing
- `npm test` *(fails: incorrect number of arguments to constructor)*

------
https://chatgpt.com/codex/tasks/task_e_687e72743cf4832ebb50528cdb86049a