### PR TITLE
Fix fetching for new pool contract layout

### DIFF
--- a/frontend/app/api/pools/route.ts
+++ b/frontend/app/api/pools/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
     } catch {
       while (true) {
         console.log('getPoolCount: null');
-        try { await poolRegistry.getPoolData(count); count++; } catch { break; }
+        try { await poolRegistry.getPoolStaticData(count); count++; } catch { break; }
       }
     }
     return NextResponse.json({ count: Number(count) });

--- a/frontend/app/api/reserve-config/route.ts
+++ b/frontend/app/api/reserve-config/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
 
     const calls = [
       { target: dep.policyManager, callData: pm.interface.encodeFunctionData('coverCooldownPeriod') },
-      { target: dep.poolRegistry, callData: pr.interface.encodeFunctionData('getPoolData', [0]) },
+      { target: dep.poolRegistry, callData: pr.interface.encodeFunctionData('getPoolStaticData', [0]) },
       { target: dep.capitalPool, callData: cp.interface.encodeFunctionData('underwriterNoticePeriod') },
     ]
 
@@ -29,9 +29,9 @@ export async function GET(req: Request) {
       ? pm.interface.decodeFunctionResult('coverCooldownPeriod', res[0].returnData)[0]
       : 0n
     const poolData = res[1].success
-      ? pr.interface.decodeFunctionResult('getPoolData', res[1].returnData)
+      ? pr.interface.decodeFunctionResult('getPoolStaticData', res[1].returnData)
       : null
-    const claimFee = poolData ? (poolData.claimFeeBps ?? poolData[6]) : 0n
+    const claimFee = poolData ? (poolData.claimFeeBps ?? poolData[4]) : 0n
     const notice = res[2].success
       ? cp.interface.decodeFunctionResult('underwriterNoticePeriod', res[2].returnData)[0]
       : 0n

--- a/frontend/app/api/underwriters/[address]/losses/[poolId]/route.ts
+++ b/frontend/app/api/underwriters/[address]/losses/[poolId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getLossDistributor } from '@/lib/lossDistributor'
 import { getUnderwriterManager } from '@/lib/underwriterManager'
+import { getCapitalPool } from '@/lib/capitalPool'
 import deployments from '../../../../../config/deployments'
 
 export async function GET(_req: Request, { params }: { params: { address: string; poolId: string } }) {
@@ -11,8 +12,9 @@ export async function GET(_req: Request, { params }: { params: { address: string
     for (const dep of deployments) {
       const rm = getUnderwriterManager(dep.underwriterManager, dep.name)
       const ld = getLossDistributor(dep.lossDistributor, dep.name)
+      const cp = getCapitalPool(dep.capitalPool, dep.name)
       try {
-        const pledge = await rm.underwriterTotalPledge(addr)
+        const [pledge] = await cp.getUnderwriterAccount(addr)
         const pending = await ld.getPendingLosses(addr, id, pledge)
         results.push({ deployment: dep.name, pending: pending.toString() })
       } catch {}

--- a/frontend/app/api/underwriters/[address]/rewards/[poolId]/route.ts
+++ b/frontend/app/api/underwriters/[address]/rewards/[poolId]/route.ts
@@ -14,7 +14,7 @@ export async function GET(_req: Request, { params }: { params: { address: string
       const rm = getUnderwriterManager(dep.underwriterManager, dep.name)
       const pr = getPoolRegistry(dep.poolRegistry, dep.name)
       try {
-        const pool = await pr.getPoolData(id)
+        const pool = await pr.getPoolStaticData(id)
         const pledge = await rm.underwriterPoolPledge(addr, id)
         const pending = await rd.pendingRewards(addr, id, pool.protocolTokenToCover, pledge)
         results.push({ deployment: dep.name, rewardToken: pool.protocolTokenToCover, pending: pending.toString() })

--- a/frontend/app/api/underwriters/[address]/route.ts
+++ b/frontend/app/api/underwriters/[address]/route.ts
@@ -28,7 +28,6 @@ export async function GET(
         const baseCalls = [
           { target: dep.capitalPool, callData: cp.interface.encodeFunctionData('getUnderwriterAccount', [addr]) },
           { target: dep.poolRegistry, callData: pr.interface.encodeFunctionData('getPoolCount') },
-          { target: dep.underwriterManager, callData: rm.interface.encodeFunctionData('underwriterTotalPledge', [addr]) },
         ]
         const baseResults = await multicall.tryAggregate(false, baseCalls)
 
@@ -62,16 +61,11 @@ export async function GET(
         }
         if (!baseResults[1].success) {
           while (true) {
-            try { await pr.getPoolData(poolCount); poolCount++ } catch { break }
+            try { await pr.getPoolStaticData(poolCount); poolCount++ } catch { break }
           }
         }
 
-        let pledge = 0n
-        if (baseResults[2].success) {
-          try {
-            pledge = rm.interface.decodeFunctionResult('underwriterTotalPledge', baseResults[2].returnData)[0]
-          } catch {}
-        }
+        const pledge = account[0]
 
         const allocCalls: { target: string; callData: string }[] = []
         for (let i = 0; i < Number(poolCount); i++) {

--- a/frontend/hooks/useReserveConfig.js
+++ b/frontend/hooks/useReserveConfig.js
@@ -18,10 +18,10 @@ export default function useReserveConfig(deployment, poolId = 0) {
         const pm = getPolicyManager(dep.policyManager, dep.name)
         const [cooldown, poolData, notice] = await Promise.all([
           pm.coverCooldownPeriod(),
-          pr.getPoolData(poolId),
+          pr.getPoolStaticData(poolId),
           cp.underwriterNoticePeriod(),
         ])
-        const claimFee = poolData.claimFeeBps ?? poolData[6]
+        const claimFee = poolData.claimFeeBps ?? poolData[4]
         setConfig({
           coverCooldownPeriod: Number(cooldown.toString()),
           claimFeeBps: Number(claimFee.toString()),


### PR DESCRIPTION
## Summary
- update frontend API routes to use `getPoolStaticData` and UnderwriterManager
- adapt reserve config hook and underwriter endpoints for new contract layout

## Testing
- `npm run test` *(fails: Cannot find module 'vitest.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68809bb2243c832ebc195c93ddb7a6fa