### PR TITLE
Add LST category to insurance markets

### DIFF
--- a/frontend/app/components/ActiveCoverages.js
+++ b/frontend/app/components/ActiveCoverages.js
@@ -166,6 +166,7 @@ export default function ActiveCoverages({ displayCurrency }) {
 
   const protocolCoverages = activeCoverages.filter((c) => c.type === "protocol")
   const stablecoinCoverages = activeCoverages.filter((c) => c.type === "stablecoin")
+  const lstCoverages = activeCoverages.filter((c) => c.type === "lst")
 
   const handleOpenModal = (coverage) => {
     setSelectedCoverage(coverage)
@@ -200,13 +201,13 @@ export default function ActiveCoverages({ displayCurrency }) {
               scope="col"
               className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
             >
-              {covers[0].type === "stablecoin" ? "Insured Token" : "Protocol"}
+              {covers[0].type === "stablecoin" ? "Insured Token" : covers[0].type === "lst" ? "LST" : "Protocol"}
             </th>
             <th
               scope="col"
               className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
             >
-              {covers[0].type === "stablecoin" ? "Reserve Token" : "Pool"}
+              {covers[0].type === "stablecoin" ? "Reserve Token" : covers[0].type === "lst" ? "Underlying" : "Pool"}
             </th>
             <th
               scope="col"
@@ -697,7 +698,9 @@ export default function ActiveCoverages({ displayCurrency }) {
                                     <p className="text-blue-800 dark:text-blue-400 text-xs leading-relaxed">
                                       {coverage.type === "stablecoin"
                                         ? `This coverage protects your ${coverage.poolName} assets against depegging events.`
-                                        : `This coverage protects your ${coverage.poolName} assets against smart contract risks and protocol failures.`}
+                                        : coverage.type === "lst"
+                                          ? `This coverage protects your ${coverage.poolName} holdings against slashing or custody risks.`
+                                          : `This coverage protects your ${coverage.poolName} assets against smart contract risks and protocol failures.`}
                                     </p>
                                   </div>
                                 </div>
@@ -729,6 +732,12 @@ export default function ActiveCoverages({ displayCurrency }) {
         <div>
           <h3 className="text-lg font-medium mb-2">Stablecoin Cover</h3>
           {renderTable(stablecoinCoverages)}
+        </div>
+      )}
+      {lstCoverages.length > 0 && (
+        <div>
+          <h3 className="text-lg font-medium mb-2">LST Cover</h3>
+          {renderTable(lstCoverages)}
         </div>
       )}
 

--- a/frontend/app/components/ManageAllocationModal.js
+++ b/frontend/app/components/ManageAllocationModal.js
@@ -18,7 +18,7 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
   const { address } = useAccount()
   const { details } = useUnderwriterDetails(address)
   const [selectedDeployment, setSelectedDeployment] = useState(deployment)
-  const [filter, setFilter] = useState("all") // "all", "protocols", "stablecoins"
+  const [filter, setFilter] = useState("all") // "all", "protocols", "stablecoins", "lsts"
 
   const YIELD_TO_PROTOCOL_MAP = {
     [YieldPlatform.AAVE]: 0,
@@ -40,6 +40,7 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
     const poolType = getProtocolType(pool.id)
     if (filter === "protocols") return poolType === "protocol"
     if (filter === "stablecoins") return poolType === "stablecoin"
+    if (filter === "lsts") return poolType === "lst"
     return true
   })
 
@@ -144,10 +145,11 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
   const getFilterCounts = () => {
     const protocolCount = allPoolsForDeployment.filter((p) => getProtocolType(p.id) === "protocol").length
     const stablecoinCount = allPoolsForDeployment.filter((p) => getProtocolType(p.id) === "stablecoin").length
-    return { protocolCount, stablecoinCount, totalCount: allPoolsForDeployment.length }
+    const lstCount = allPoolsForDeployment.filter((p) => getProtocolType(p.id) === "lst").length
+    return { protocolCount, stablecoinCount, lstCount, totalCount: allPoolsForDeployment.length }
   }
 
-  const { protocolCount, stablecoinCount, totalCount } = getFilterCounts()
+  const { protocolCount, stablecoinCount, lstCount, totalCount } = getFilterCounts()
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Manage Protocol Allocation">
@@ -200,6 +202,16 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
             }`}
           >
             Stablecoins ({stablecoinCount})
+          </button>
+          <button
+            onClick={() => setFilter("lsts")}
+            className={`flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors ${
+              filter === "lsts"
+                ? "bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm"
+                : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+            }`}
+          >
+            LSTs ({lstCount})
           </button>
         </div>
       </div>
@@ -309,10 +321,12 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
                         className={`px-2 py-0.5 text-xs rounded-full font-medium ${
                           poolType === "protocol"
                             ? "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400"
-                            : "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                            : poolType === "stablecoin"
+                                ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                                : "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400"
                         }`}
                       >
-                        {poolType === "protocol" ? "Protocol" : "Stablecoin"}
+                        {poolType === "protocol" ? "Protocol" : poolType === "stablecoin" ? "Stablecoin" : "LST"}
                       </span>
                     </div>
                     <div className="flex items-center gap-4 mt-1">

--- a/frontend/app/components/MarketsTable.js
+++ b/frontend/app/components/MarketsTable.js
@@ -19,7 +19,7 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
   const [modalOpen, setModalOpen] = useState(false)
   const [selectedPool, setSelectedPool] = useState(null)
   const { pools, loading } = usePools()
-  const [typeFilter, setTypeFilter] = useState('all') // 'all', 'protocol', 'stablecoin'
+  const [typeFilter, setTypeFilter] = useState('all') // 'all', 'protocol', 'stablecoin', 'lst'
 
   const grouped = {}
   for (const pool of pools) {
@@ -127,12 +127,12 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
 
       {/* Market type filter */}
       <div className="mb-4 inline-flex rounded-md shadow-sm">
-        {['all', 'protocol', 'stablecoin'].map((type, idx) => (
+        {['all', 'protocol', 'stablecoin', 'lst'].map((type, idx, arr) => (
           <button
             key={type}
             type="button"
             className={`px-3 py-2 text-sm font-medium border border-gray-300 dark:border-gray-600 focus:z-10 ${
-              idx === 0 ? 'rounded-l-md' : idx === 2 ? 'rounded-r-md -ml-px' : '-ml-px'
+              idx === 0 ? 'rounded-l-md' : idx === arr.length - 1 ? 'rounded-r-md -ml-px' : '-ml-px'
             } ${
               typeFilter === type
                 ? 'bg-blue-600 text-white'
@@ -140,7 +140,7 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
             }`}
             onClick={() => setTypeFilter(type)}
           >
-            {type === 'all' ? 'All' : type === 'protocol' ? 'Protocol' : 'Stablecoin'}
+            {type === 'all' ? 'All' : type === 'protocol' ? 'Protocol' : type === 'stablecoin' ? 'Stablecoin' : 'LSTs'}
           </button>
         ))}
       </div>

--- a/frontend/app/components/UnderwritingPositions.js
+++ b/frontend/app/components/UnderwritingPositions.js
@@ -141,6 +141,7 @@ export default function UnderwritingPositions({ displayCurrency }) {
 
   const protocolPositions = underwritingPositions.filter((p) => p.type === "protocol")
   const stablecoinPositions = underwritingPositions.filter((p) => p.type === "stablecoin")
+  const lstPositions = underwritingPositions.filter((p) => p.type === "lst")
 
   const showPendingLoss = underwritingPositions.some((p) => p.pendingLoss > 0)
 
@@ -282,13 +283,13 @@ export default function UnderwritingPositions({ displayCurrency }) {
                         scope="col"
                         className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
                       >
-                        {positions[0].type === "stablecoin" ? "Insured Token" : "Protocol"}
+                        {positions[0].type === "stablecoin" ? "Insured Token" : positions[0].type === "lst" ? "LST" : "Protocol"}
                       </th>
                       <th
                         scope="col"
                         className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
                       >
-                        {positions[0].type === "stablecoin" ? "Reserve Token" : "Pool"}
+                        {positions[0].type === "stablecoin" ? "Reserve Token" : positions[0].type === "lst" ? "Underlying" : "Pool"}
                       </th>
                       <th
                         scope="col"
@@ -811,6 +812,8 @@ export default function UnderwritingPositions({ displayCurrency }) {
         {renderTables(protocolPositions, "Protocol Cover")}
         {stablecoinPositions.some((p) => p.status === "active") &&
           renderTables(stablecoinPositions, "Stablecoin Cover")}
+        {lstPositions.some((p) => p.status === "active") &&
+          renderTables(lstPositions, "LST Cover")}
         <div className="mt-4 flex flex-wrap justify-end gap-2">
           <button
             onClick={() => setShowAllocModal(true)}

--- a/frontend/app/config/tokenNameMap.js
+++ b/frontend/app/config/tokenNameMap.js
@@ -16,6 +16,7 @@ export const PROTOCOL_NAME_MAP = {
   1: 'DAI',
   2: 'USDM',
   3: 'USDT',
+  4: 'LST Protocol',
 };
 
 export const PROTOCOL_DESCRIPTION_MAP = {
@@ -23,6 +24,7 @@ export const PROTOCOL_DESCRIPTION_MAP = {
   1: 'CDP Stablecoin',
   2: 'CDP Stablecoin',
   3: 'Stablecoin',
+  4: 'Liquid Staking Token',
 };
 
 export const PROTOCOL_LOGO_MAP = {
@@ -30,6 +32,7 @@ export const PROTOCOL_LOGO_MAP = {
   1: '/images/stablecoins/dai.svg',
   2: '/images/stablecoins/usdm.png',
   3: '/images/stablecoins/usdt.png',
+  4: '/placeholder-logo.png',
 };
 
 // Categorise protocols so the frontend can filter markets. The default value is
@@ -39,6 +42,7 @@ export const PROTOCOL_TYPE_MAP = {
   1: 'stablecoin',
   2: 'stablecoin',
   3: 'stablecoin',
+  4: 'lst', // example mapping for LST protocols
 };
 
 


### PR DESCRIPTION
## Summary
- extend protocol type mapping for LSTs
- support filtering LST markets in insurance pages
- display LST positions and coverages alongside stablecoins and protocols

## Testing
- `npm test` *(fails: ENOENT MaliciousToken.sol)*

------
https://chatgpt.com/codex/tasks/task_e_6881f8a08824832e8329cada1e0c9da2