### PR TITLE
Fix reserve token display on dashboard

### DIFF
--- a/frontend/app/components/ActiveCoverages.js
+++ b/frontend/app/components/ActiveCoverages.js
@@ -103,6 +103,8 @@ export default function ActiveCoverages({ displayCurrency }) {
         type: getProtocolType(pool.id),
         pool: pool.protocolTokenToCover,
         poolName: getTokenName(pool.protocolTokenToCover),
+        reserveToken: pool.underlyingAsset,
+        reserveTokenName: getTokenName(pool.underlyingAsset),
         premium: Number(pool.premiumRateBps || 0) / 100,
         capacity,
       }
@@ -269,14 +271,28 @@ export default function ActiveCoverages({ displayCurrency }) {
                   <div className="flex items-center">
                     <div className="flex-shrink-0 h-6 w-6 mr-2">
                       <Image
-                        src={getTokenLogo(coverage.pool) || "/placeholder.svg"}
-                        alt={getProtocolName(coverage.poolName)}
+                        src={
+                          getTokenLogo(
+                            coverage.type === "protocol"
+                              ? coverage.pool
+                              : coverage.reserveToken,
+                          ) || "/placeholder.svg"
+                        }
+                        alt={
+                          coverage.type === "protocol"
+                            ? getProtocolName(coverage.poolName)
+                            : getTokenName(coverage.reserveToken)
+                        }
                         width={24}
                         height={24}
                         className="rounded-full"
                       />
                     </div>
-                    <div className="text-sm text-gray-900 dark:text-white">{coverage.poolName}</div>
+                    <div className="text-sm text-gray-900 dark:text-white">
+                      {coverage.type === "protocol"
+                        ? coverage.poolName
+                        : coverage.reserveTokenName}
+                    </div>
                   </div>
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">

--- a/frontend/app/components/UnderwritingPositions.js
+++ b/frontend/app/components/UnderwritingPositions.js
@@ -80,6 +80,8 @@ export default function UnderwritingPositions({ displayCurrency }) {
           type: getProtocolType(pool.id),
           pool: pool.protocolTokenToCover,
           poolName: getTokenName(pool.id),
+          reserveToken: pool.underlyingAsset,
+          reserveTokenName: getTokenName(pool.underlyingAsset),
           poolId: pid,
           pendingLoss,
           pendingLossUsd: pendingLoss * tokenPriceUsd,
@@ -349,14 +351,28 @@ export default function UnderwritingPositions({ displayCurrency }) {
                             <div className="flex items-center">
                               <div className="flex-shrink-0 h-6 w-6 mr-2">
                                 <Image
-                                  src={getTokenLogo(position.pool) || "/placeholder.svg"}
-                                  alt={getTokenName(position.pool)}
+                                  src={
+                                    getTokenLogo(
+                                      position.type === "protocol"
+                                        ? position.pool
+                                        : position.reserveToken,
+                                    ) || "/placeholder.svg"
+                                  }
+                                  alt={
+                                    position.type === "protocol"
+                                      ? getTokenName(position.pool)
+                                      : getTokenName(position.reserveToken)
+                                  }
                                   width={24}
                                   height={24}
                                   className="rounded-full"
                                 />
                               </div>
-                              <div className="text-sm text-gray-900 dark:text-white">{getTokenName(position.pool)}</div>
+                              <div className="text-sm text-gray-900 dark:text-white">
+                                {position.type === "protocol"
+                                  ? getTokenName(position.pool)
+                                  : position.reserveTokenName}
+                              </div>
                             </div>
                             <div className="mt-1 sm:hidden text-xs text-gray-500 dark:text-gray-400">
                               {displayCurrency === "native"
@@ -477,7 +493,10 @@ export default function UnderwritingPositions({ displayCurrency }) {
                                         <div>
                                           <h3 className="text-lg font-semibold text-white">Position Management</h3>
                                           <p className="text-slate-300 text-sm">
-                                            {getProtocolName(position.poolId)} • {getTokenName(position.pool)}
+                                            {getProtocolName(position.poolId)} •{' '}
+                                            {position.type === "protocol"
+                                              ? getTokenName(position.pool)
+                                              : position.reserveTokenName}
                                           </p>
                                         </div>
                                       </div>


### PR DESCRIPTION
## Summary
- show the pool's underlying token as the reserve token
- adjust ActiveCoverages and UnderwritingPositions tables

## Testing
- `npm test` *(fails: Failed to resolve import "@/lib/utils" from test files)*

------
https://chatgpt.com/codex/tasks/task_e_68820ce290cc832e8f826a52a219b2e2