### PR TITLE
Display risk rating in allocation modal

### DIFF
--- a/frontend/app/components/ManageAllocationModal.js
+++ b/frontend/app/components/ManageAllocationModal.js
@@ -333,6 +333,14 @@ export default function ManageAllocationModal({ isOpen, onClose, deployment }) {
                       <span className="text-xs text-green-600 dark:text-green-400 font-medium">
                         {formatPercentage(yieldRate)} APY
                       </span>
+                      {pool.riskRating !== null && (
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          Risk Rating:{" "}
+                          <span className="text-gray-700 dark:text-gray-300">
+                            {pool.riskRating}
+                          </span>
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- show risk rating in Manage Protocol Allocation modal

## Testing
- `npm test` *(fails: Failed to resolve import "@/lib/utils" in component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68822012534c832eaffb160931f65c2e