### PR TITLE
Fix backstop pool deposits

### DIFF
--- a/frontend/app/components/CatPoolDeposits.js
+++ b/frontend/app/components/CatPoolDeposits.js
@@ -14,6 +14,7 @@ import {
   getUsdcAddress,
   getUsdcDecimals,
   getCatShareDecimals,
+  drawFund,
 } from "../../lib/catPool"
 import ClaimRewardsModal from "./ClaimRewardsModal"
 import RequestWithdrawalModal from "./RequestWithdrawalModal"
@@ -154,6 +155,24 @@ export default function CatPoolDeposits({ displayCurrency, refreshTrigger }) {
       setPendingWithdrawal(null)
     } catch (error) {
       console.error('Failed to withdraw:', error)
+    }
+  }
+
+  const handleDrawFund = async () => {
+    if (!pendingWithdrawal) return
+    try {
+      const dec = await getUsdcDecimals()
+      const amountBn = ethers.utils.parseUnits(
+        Number(pendingWithdrawal.value).toFixed(dec),
+        dec,
+      )
+      const tx = await drawFund(amountBn)
+      setTxHash(tx.hash)
+      await refresh()
+      await refreshWithdrawal()
+      setPendingWithdrawal(null)
+    } catch (error) {
+      console.error('Failed to draw fund:', error)
     }
   }
 
@@ -435,12 +454,20 @@ export default function CatPoolDeposits({ displayCurrency, refreshTrigger }) {
                   <td className="px-6 py-4 whitespace-nowrap text-right">
                     <div className="flex items-center justify-end space-x-2">
                       {withdrawalReady && (
-                        <button
-                          onClick={handleExecuteWithdrawal}
-                          className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-100 dark:bg-indigo-900/30 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 rounded-md transition-colors"
-                        >
-                          Withdraw
-                        </button>
+                        <>
+                          <button
+                            onClick={handleExecuteWithdrawal}
+                            className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-100 dark:bg-indigo-900/30 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 rounded-md transition-colors"
+                          >
+                            Withdraw
+                          </button>
+                          <button
+                            onClick={handleDrawFund}
+                            className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-purple-700 dark:text-purple-300 bg-purple-100 dark:bg-purple-900/30 hover:bg-purple-200 dark:hover:bg-purple-900/50 rounded-md transition-colors"
+                          >
+                            Draw Fund
+                          </button>
+                        </>
                       )}
                     </div>
                   </td>

--- a/frontend/app/components/CatPoolModal.js
+++ b/frontend/app/components/CatPoolModal.js
@@ -5,7 +5,13 @@ import Image from "next/image"
 import { Info, AlertTriangle, Clock, TrendingUp } from "lucide-react"
 import Modal from "./Modal"
 import { formatCurrency } from "../utils/formatting"
-import { getCatPoolWithSigner, getUsdcAddress, getUsdcDecimals, getCatShareAddress } from "../../lib/catPool"
+import {
+  getCatPoolWithSigner,
+  getUsdcAddress,
+  getUsdcDecimals,
+  getCatShareAddress,
+  depositWithApproval,
+} from "../../lib/catPool"
 import deployments from "../config/deployments"
 import { getERC20WithSigner, getTokenDecimals } from "../../lib/erc20"
 import { getTokenLogo } from "../config/tokenNameMap"
@@ -143,14 +149,13 @@ export default function CatPoolModal({
     if (!amount) return
     setIsSubmitting(true)
     try {
-      const cp = await getCatPoolWithSigner()
       if (isDeposit) {
         const dec = await getUsdcDecimals()
         const amountBn = ethers.utils.parseUnits(amount, dec)
-        const tx = await cp.depositLiquidity(amountBn)
+        const tx = await depositWithApproval(amountBn)
         setTxHash(tx.hash)
-        await tx.wait()
       } else {
+        const cp = await getCatPoolWithSigner()
         const dec = await getUsdcDecimals()
         const amountBn = ethers.utils.parseUnits(amount, dec)
         const shareAddr = await getCatShareAddress()


### PR DESCRIPTION
## Summary
- add depositWithApproval helper to handle token approval and deposit
- update CatPoolModal deposit logic to use new helper
- expose requestWithdrawal and drawFund functions
- allow drawing funds once withdrawal cooldown ends

## Testing
- `npm test` *(fails: ENOENT no such file or directory '/workspace/monorepo/contracts/test/MaliciousToken.sol')*

------
https://chatgpt.com/codex/tasks/task_e_688373526474832e9537a1028c9ce48b