### PR TITLE
Fix ERC20 ABI usage with ethers v6

### DIFF
--- a/frontend/app/api/catpool/user/[address]/route.ts
+++ b/frontend/app/api/catpool/user/[address]/route.ts
@@ -15,7 +15,13 @@ export async function GET(req: Request, { params }: { params: { address: string 
 
     const addr = params.address.toLowerCase()
     const catShareAddr = await cp.catShareToken()
-    const token = new ethers.Contract(catShareAddr, ERC20, getProvider(dep.name))
+    const token = new ethers.Contract(
+      catShareAddr,
+      // Ethers v6 does not automatically extract the ABI from Hardhat artifacts
+      // so we need to pass the `abi` array explicitly.
+      ERC20.abi,
+      getProvider(dep.name),
+    )
     const multicall = getMulticallReader(dep.multicallReader, dep.name)
 
     const calls = [

--- a/frontend/hooks/useCatPoolUserInfo.js
+++ b/frontend/hooks/useCatPoolUserInfo.js
@@ -14,7 +14,8 @@ export default function useCatPoolUserInfo(address) {
       const cp = await getCatPoolWithSigner()
       const catShareAddr = await cp.catShareToken()
       const provider = new ethers.providers.Web3Provider(window.ethereum)
-      const token = new ethers.Contract(catShareAddr, ERC20, provider)
+      // Pass the ABI explicitly when using ethers v6
+      const token = new ethers.Contract(catShareAddr, ERC20.abi, provider)
       const [balance, totalSupply, liquid] = await Promise.all([
         token.balanceOf(address),
         token.totalSupply(),


### PR DESCRIPTION
## Summary
- fix the catastrophe pool user API to explicitly pass ERC20 ABI
- update user info hook to use ERC20.abi

## Testing
- `npm test` *(fails: ENOENT no such file or directory 'contracts/test/MaliciousToken.sol')*

------
https://chatgpt.com/codex/tasks/task_e_68886f536244832e9bef44d187e1ea96