### PR TITLE
Update withdrawal calls to use UnderwriterManager

### DIFF
--- a/frontend/app/api/coverpool/execute-withdrawal/route.ts
+++ b/frontend/app/api/coverpool/execute-withdrawal/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getCapitalPoolWriter } from '../../../../lib/capitalPool';
+import { getUnderwriterManagerWriter } from '../../../../lib/underwriterManager';
 import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
@@ -7,8 +7,8 @@ export async function POST(req: Request) {
     const url = new URL(req.url);
     const depName = url.searchParams.get('deployment');
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
-    const cp = getCapitalPoolWriter(dep.capitalPool, dep.name);
-    const tx = await cp.executeWithdrawal(0);
+    const rm = getUnderwriterManagerWriter(dep.underwriterManager, dep.name);
+    const tx = await rm.executeWithdrawal(0);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });
   } catch (err: any) {

--- a/frontend/app/api/coverpool/request-withdrawal/route.ts
+++ b/frontend/app/api/coverpool/request-withdrawal/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getCapitalPoolWriter } from '../../../../lib/capitalPool';
+import { getUnderwriterManagerWriter } from '../../../../lib/underwriterManager';
 import deployments from '../../../config/deployments';
 
 export async function POST(req: Request) {
@@ -7,7 +8,9 @@ export async function POST(req: Request) {
     const { shares, deployment: depName } = await req.json();
     const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
     const cp = getCapitalPoolWriter(dep.capitalPool, dep.name);
-    const tx = await cp.requestWithdrawal(shares);
+    const rm = getUnderwriterManagerWriter(dep.underwriterManager, dep.name);
+    const amount = await cp.sharesToValue(shares);
+    const tx = await rm.requestWithdrawal(amount);
     await tx.wait();
     return NextResponse.json({ txHash: tx.hash });
   } catch (err: any) {

--- a/frontend/app/components/ManageCoverageModal.js
+++ b/frontend/app/components/ManageCoverageModal.js
@@ -136,7 +136,9 @@ export default function ManageCoverageModal({
       } else if (action === "decrease") {
         if (!shares) throw new Error("share info missing")
         const cp = await getCapitalPoolWithSigner(depInfo.capitalPool)
-        tx = await cp.requestWithdrawal(shares)
+        const rm = await getUnderwriterManagerWithSigner(depInfo.underwriterManager)
+        const amount = await cp.sharesToValue(shares)
+        tx = await rm.requestWithdrawal(amount)
         setTxHash(tx.hash)
         await tx.wait()
       } else if (action === "increase") {

--- a/frontend/app/components/UnderwritingPositions.js
+++ b/frontend/app/components/UnderwritingPositions.js
@@ -12,7 +12,6 @@ import useUnderwriterDetails from "../../hooks/useUnderwriterDetails"
 import usePools from "../../hooks/usePools"
 import useYieldAdapters from "../../hooks/useYieldAdapters"
 import { ethers } from "ethers"
-import { getCapitalPoolWithSigner } from "../../lib/capitalPool"
 import { getUnderwriterManagerWithSigner } from "../../lib/underwriterManager"
 import { getTokenName, getTokenLogo, getProtocolLogo, getProtocolName, getProtocolType } from "../config/tokenNameMap"
 import { getDeployment } from "../config/deployments"
@@ -152,11 +151,10 @@ export default function UnderwritingPositions({ displayCurrency }) {
     setIsRequesting(true)
     try {
       const dep = getDeployment(selectedPosition.deployment)
-      const cp = await getCapitalPoolWithSigner(dep.capitalPool, dep.name)
+      const rm = await getUnderwriterManagerWithSigner(dep.underwriterManager)
       const dec = pools.find((p) => p.deployment === selectedPosition.deployment)?.underlyingAssetDecimals ?? 6
       const amountBn = ethers.utils.parseUnits(withdrawalData.amount.toString(), dec)
-      const shares = await cp.valueToShares(amountBn)
-      const tx = await cp.requestWithdrawal(shares)
+      const tx = await rm.requestWithdrawal(amountBn)
       await tx.wait()
 
       const readyDate = Date.now() + 30 * 24 * 60 * 60 * 1000 // 30 days from now
@@ -180,8 +178,8 @@ export default function UnderwritingPositions({ displayCurrency }) {
     setIsExecuting(true)
     try {
       const dep = getDeployment(position.deployment)
-      const cp = await getCapitalPoolWithSigner(dep.capitalPool, dep.name)
-      const tx = await cp.executeWithdrawal(0)
+      const rm = await getUnderwriterManagerWithSigner(dep.underwriterManager)
+      const tx = await rm.executeWithdrawal(0)
       await tx.wait()
 
       setWithdrawalRequests((prev) => {
@@ -200,8 +198,8 @@ export default function UnderwritingPositions({ displayCurrency }) {
     setIsCancelling(true)
     try {
       const dep = getDeployment(position.deployment)
-      const cp = await getCapitalPoolWithSigner(dep.capitalPool, dep.name)
-      const tx = await cp.cancelWithdrawalRequest()
+      const rm = await getUnderwriterManagerWithSigner(dep.underwriterManager)
+      const tx = await rm.cancelWithdrawal(0)
       await tx.wait()
 
       setWithdrawalRequests((prev) => {


### PR DESCRIPTION
## Summary
- update withdrawal code paths to use UnderwriterManager
- translate shares to amounts when requesting withdrawals

## Testing
- `npm test` *(fails: Failed to resolve import `@/lib/utils` in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a5774fda8832ea13ec4c863556113