### PR TITLE
Refresh claims data on dashboard

### DIFF
--- a/frontend/app/components/ClaimsSection.js
+++ b/frontend/app/components/ClaimsSection.js
@@ -16,9 +16,9 @@ export default function ClaimsSection({ displayCurrency }) {
   const [activeTab, setActiveTab] = useState("affected") // 'affected' or 'history'
   const [claimingId, setClaimingId] = useState(null)
   const { address } = useAccount()
-  const { claims } = useClaims()
+  const { claims, refresh: refreshClaims } = useClaims()
   const { pools } = usePools()
-  const { positions: affectedPositions } = useUnderwriterClaims(address)
+  const { positions: affectedPositions, refresh: refreshPositions } = useUnderwriterClaims(address)
 
   const handleClaimCollateral = async (id) => {
     try {
@@ -26,6 +26,8 @@ export default function ClaimsSection({ displayCurrency }) {
       const manager = await getClaimsCollateralManagerWithSigner()
       const tx = await manager.claimCollateral(id)
       await tx.wait()
+      refreshPositions()
+      refreshClaims()
     } catch (err) {
       console.error("Claim collateral failed", err)
     } finally {

--- a/frontend/hooks/useClaims.js
+++ b/frontend/hooks/useClaims.js
@@ -1,54 +1,28 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 
 export default function useClaims() {
   const [claims, setClaims] = useState([])
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const url = process.env.NEXT_PUBLIC_SUBGRAPH_URL
-        if (!url) throw new Error('NEXT_PUBLIC_SUBGRAPH_URL not set')
-
-        const pageSize = 1000
-        let skip = 0
-        const results = []
-
-        while (true) {
-          const query = `{ claims(first: ${pageSize}, skip: ${skip}, orderBy: timestamp, orderDirection: desc) { policyId poolId claimant coverage netPayoutToClaimant claimFee protocolTokenAmountReceived timestamp transactionHash } }`
-          const res = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ query }),
-          })
-          const json = await res.json()
-          const batch = json?.data?.claims || []
-          results.push(...batch)
-          if (batch.length < pageSize) break
-          skip += pageSize
-        }
-
-        const claimsData = results.map((c) => ({
-          transactionHash: c.transactionHash,
-          timestamp: Number(c.timestamp),
-          policyId: Number(c.policyId),
-          poolId: Number(c.poolId),
-          claimant: c.claimant,
-          coverage: c.coverage,
-          netPayoutToClaimant: c.netPayoutToClaimant,
-          claimFee: c.claimFee,
-          protocolTokenAmountReceived: c.protocolTokenAmountReceived,
-        }))
-
-        setClaims(claimsData)
-      } catch (err) {
-        console.error('Failed to load claims', err)
-      } finally {
-        setLoading(false)
-      }
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/claims')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setClaims(data.claims || [])
+    } catch (err) {
+      console.error('Failed to load claims', err)
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
 
-  return { claims, loading }
+  useEffect(() => {
+    load()
+    const id = setInterval(load, 30000)
+    return () => clearInterval(id)
+  }, [load])
+
+  return { claims, loading, refresh: load }
 }


### PR DESCRIPTION
## Summary
- fetch claims via API and poll periodically
- allow reloading affected positions
- refresh claim tables after claiming collateral

## Testing
- `npm install --force` *(fails: peer dependency warnings)*
- `npm run test` *(fails: failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_688a86bc30f8832e9910ef8fa27e49e3