### PR TITLE
Use risk adjusted pledge for positions

### DIFF
--- a/frontend/app/components/UnderwritingPositions.js
+++ b/frontend/app/components/UnderwritingPositions.js
@@ -60,24 +60,10 @@ export default function UnderwritingPositions({ displayCurrency }) {
         if (!pool) continue
         const protocol = getTokenName(pool.id)
         const dec = pool.underlyingAssetDecimals ?? 6
-        const deposited = Number(
-          ethers.utils.formatUnits(d.totalDepositedAssetPrincipal, dec),
+        const riskAdjustedStr = d.riskAdjustedPledges?.[pid] ?? "0"
+        const amount = Number(
+          ethers.utils.formatUnits(riskAdjustedStr, dec),
         )
-        // Sum pending losses across all allocated pools for this deployment
-        const pendingLossTotal = Object.entries(d.pendingLosses || {}).reduce(
-          (sum, [lossPid, loss]) => {
-            const lossPool = pools.find(
-              (pl) =>
-                pl.deployment === d.deployment &&
-                Number(pl.id) === Number(lossPid),
-            )
-            if (!lossPool) return sum
-            const lossDec = lossPool.underlyingAssetDecimals ?? dec
-            return sum + Number(ethers.utils.formatUnits(loss, lossDec))
-          },
-          0,
-        )
-        const amount = Math.max(0, deposited - pendingLossTotal)
         const pendingLossStr = d.pendingLosses?.[pid] ?? "0"
         const pendingLoss = Number(ethers.utils.formatUnits(pendingLossStr, pool.underlyingAssetDecimals ?? 6))
         const positionId = `${d.deployment}-${pid}`


### PR DESCRIPTION
## Summary
- show underwriter positions using `getRiskAdjustedPledge`
- fetch risk adjusted pledge values in the underwriter details API

## Testing
- `npx vitest run` *(fails: Error: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688c7d8bd734832e8e55638b74ffc3dd