### PR TITLE
Add pending loss display

### DIFF
--- a/frontend/app/components/ClaimsSection.js
+++ b/frontend/app/components/ClaimsSection.js
@@ -77,6 +77,7 @@ export default function ClaimsSection({ displayCurrency }) {
       tokenName,
       amount: p.amount,
       value: p.amount, // value in native asset unknown
+      pendingLoss: p.pendingLoss,
       claimDate: p.claimDate,
       claimed: p.claimed,
     }
@@ -174,6 +175,18 @@ export default function ClaimsSection({ displayCurrency }) {
                     scope="col"
                     className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell"
                   >
+                    Pending Losses
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell"
+                  >
+                    Claim Status
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell"
+                  >
                     {activeTab === "affected" ? "Claim Date" : "Status"}
                   </th>
                   <th
@@ -230,6 +243,16 @@ export default function ClaimsSection({ displayCurrency }) {
                     <td className="px-3 sm:px-6 py-4 whitespace-nowrap hidden sm:table-cell">
                       <div className="text-sm text-gray-900 dark:text-white">
                         {formatCurrency(claim.value, "USD", displayCurrency)}
+                      </div>
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap hidden sm:table-cell">
+                      <div className="text-sm text-gray-900 dark:text-white">
+                        {formatCurrency(claim.pendingLoss || 0, "USD", displayCurrency)}
+                      </div>
+                    </td>
+                    <td className="px-3 sm:px-6 py-4 whitespace-nowrap hidden sm:table-cell">
+                      <div className="text-sm text-gray-900 dark:text-white">
+                        {claim.claimed ? 'Claimed' : 'Unclaimed'}
                       </div>
                     </td>
                     <td className="px-3 sm:px-6 py-4 whitespace-nowrap hidden sm:table-cell">

--- a/frontend/hooks/useUnderwriterClaims.js
+++ b/frontend/hooks/useUnderwriterClaims.js
@@ -3,6 +3,8 @@ import { ethers } from 'ethers'
 import useClaims from './useClaims'
 import usePools from './usePools'
 import { getClaimsCollateralManager } from '../lib/claimsCollateralManager'
+import { getLossDistributor } from '../lib/lossDistributor'
+import { getUnderwriterManager } from '../lib/underwriterManager'
 
 export default function useUnderwriterClaims(address) {
   const { claims } = useClaims()
@@ -14,20 +16,31 @@ export default function useUnderwriterClaims(address) {
     setLoading(true)
     try {
       const manager = getClaimsCollateralManager()
+      const ld = getLossDistributor()
+      const uwm = getUnderwriterManager()
       const results = []
       for (const c of claims) {
-        const pool = pools.find(p => Number(p.id) === c.poolId)
+        const pool = pools.find((p) => Number(p.id) === c.poolId)
         if (!pool) continue
         try {
           const [amount, claimed] = await manager.getUnderwriterClaimStatus(c.policyId, address)
+          const pledge = await uwm.underwriterPoolPledge(address, c.poolId)
+          const pendingLossBn = await ld.getPendingLosses(address, c.poolId, pledge)
+          const pendingLoss = Number(
+            ethers.utils.formatUnits(pendingLossBn, pool.underlyingAssetDecimals ?? 6),
+          )
+
           if (amount > 0n) {
             const { collateralAsset } = await manager.claims(c.policyId)
-            const amountNum = Number(ethers.utils.formatUnits(amount, pool.protocolTokenDecimals ?? 18))
+            const amountNum = Number(
+              ethers.utils.formatUnits(amount, pool.protocolTokenDecimals ?? 18),
+            )
             results.push({
               id: c.policyId,
               poolId: c.poolId,
               collateralAsset,
               amount: amountNum,
+              pendingLoss,
               claimed,
               claimDate: new Date(c.timestamp * 1000).toISOString(),
             })


### PR DESCRIPTION
## Summary
- show pending loss and claim status in Claims & Affected Positions
- fetch pending losses and status for underwriters via new calls to LossDistributor and UnderwriterManager

## Testing
- `npm test` *(fails: ENOENT MaliciousToken.sol)*
- `cd frontend && npm test` *(fails: vitest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c7edd00f4832e927845f7a2abc1f4