### PR TITLE
Update LayerCover logo with themed images

### DIFF
--- a/frontend/app/components/MobileNav.js
+++ b/frontend/app/components/MobileNav.js
@@ -52,7 +52,16 @@ export default function MobileNav() {
           <div className="fixed inset-y-0 right-0 w-full max-w-xs bg-white dark:bg-gray-800 shadow-xl flex flex-col">
             <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
               <h2 className="flex items-center text-xl font-bold text-blue-600 dark:text-blue-400">
-                <img src="/layercover-logo.svg" alt="LayerCover logo" className="h-8 w-8 mr-2" />
+                <img
+                  src="/layercover-logo-light.svg"
+                  alt="LayerCover logo"
+                  className="h-8 w-8 mr-2 block dark:hidden"
+                />
+                <img
+                  src="/layercover-logo-dark.svg"
+                  alt="LayerCover logo"
+                  className="h-8 w-8 mr-2 hidden dark:block"
+                />
                 LayerCover
               </h2>
               <button

--- a/frontend/app/components/Navbar.js
+++ b/frontend/app/components/Navbar.js
@@ -29,64 +29,36 @@ export default function Navbar() {
         <div className="flex justify-between h-16">
           <div className="flex items-center md:hidden">
             <Link href="/" className="flex-shrink-0 flex items-center">
-              <div className="flex items-center space-x-3">
-                <div className="relative">
-                  <div className="w-10 h-10 bg-gradient-to-br from-slate-600 to-slate-800 rounded-lg flex items-center justify-center shadow-lg">
-                    <svg
-                      className="w-6 h-6 text-white"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-                      />
-                    </svg>
-                  </div>
-                  <div className="absolute -top-1 -right-1 w-3 h-3 bg-emerald-500 rounded-full border-2 border-white dark:border-gray-800"></div>
-                </div>
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900 dark:text-white">
-                    Layer<span className="text-slate-600 dark:text-slate-400">Cover</span>
-                  </h1>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 -mt-1">Insurance Protocol</p>
-                </div>
-              </div>
+              <img
+                src="/layercover-logo-light.svg"
+                alt="LayerCover logo"
+                className="h-10 w-auto mr-2 block dark:hidden"
+              />
+              <img
+                src="/layercover-logo-dark.svg"
+                alt="LayerCover logo"
+                className="h-10 w-auto mr-2 hidden dark:block"
+              />
+              <span className="sr-only">LayerCover</span>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Insurance Protocol</p>
             </Link>
           </div>
 
           {/* Desktop Navigation with Logo */}
           <div className="hidden md:flex items-center space-x-8">
             <Link href="/" className="flex items-center space-x-3">
-              <div className="relative">
-                <div className="w-10 h-10 bg-gradient-to-br from-slate-600 to-slate-800 rounded-lg flex items-center justify-center shadow-lg">
-                  <svg
-                    className="w-6 h-6 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-                    />
-                  </svg>
-                </div>
-                <div className="absolute -top-1 -right-1 w-3 h-3 bg-emerald-500 rounded-full border-2 border-white dark:border-gray-800"></div>
-              </div>
-              <div>
-                <h1 className="text-xl font-bold text-gray-900 dark:text-white">
-                  Layer<span className="text-slate-600 dark:text-slate-400">Cover</span>
-                </h1>
-                <p className="text-xs text-gray-500 dark:text-gray-400 -mt-1">Insurance Protocol</p>
-              </div>
+              <img
+                src="/layercover-logo-light.svg"
+                alt="LayerCover logo"
+                className="h-10 w-auto block dark:hidden"
+              />
+              <img
+                src="/layercover-logo-dark.svg"
+                alt="LayerCover logo"
+                className="h-10 w-auto hidden dark:block"
+              />
+              <span className="sr-only">LayerCover</span>
+              <p className="text-xs text-gray-500 dark:text-gray-400 ml-2">Insurance Protocol</p>
             </Link>
             {navigation.map((item) => (
               <Link

--- a/frontend/public/layercover-logo-dark.svg
+++ b/frontend/public/layercover-logo-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" viewBox="0 0 120 24">
+  <rect width="120" height="24" fill="#ffffff" />
+  <path d="M12 2 L20 5 V11 C20 16.55 16.5 21.5 12 22 C7.5 21.5 4 16.55 4 11 V5 L12 2 Z" fill="#1e40af"/>
+  <text x="32" y="16" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#1e40af">LayerCover</text>
+</svg>

--- a/frontend/public/layercover-logo-light.svg
+++ b/frontend/public/layercover-logo-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" viewBox="0 0 120 24">
+  <rect width="120" height="24" fill="#1e40af" />
+  <path d="M12 2 L20 5 V11 C20 16.55 16.5 21.5 12 22 C7.5 21.5 4 16.55 4 11 V5 L12 2 Z" fill="white"/>
+  <text x="32" y="16" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="white">LayerCover</text>
+</svg>


### PR DESCRIPTION
## Summary
- introduce light and dark version LayerCover logos
- swap logos in Navbar and MobileNav depending on theme

## Testing
- `npm test` *(fails: ENOENT for MaliciousToken.sol)*

------
https://chatgpt.com/codex/tasks/task_e_688c8822fba4832e8920e1b8fe3ce288