### PR TITLE
Update Cover Available calculation

### DIFF
--- a/frontend/app/api/capitalpool/available/route.ts
+++ b/frontend/app/api/capitalpool/available/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getCapitalPool, getUnderlyingAssetDecimals } from '../../../../lib/capitalPool';
+import deployments from '../../../config/deployments';
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const depName = url.searchParams.get('deployment');
+    const dep = deployments.find((d) => d.name === depName) ?? deployments[0];
+    const cp = getCapitalPool(dep.capitalPool, dep.name);
+    const [nav, unsettled, decimals] = await Promise.all([
+      cp.getTotalNAV(),
+      cp.unsettledPayouts(),
+      getUnderlyingAssetDecimals(dep.capitalPool, dep.name),
+    ]);
+    const available = nav.sub(unsettled);
+    return NextResponse.json({ available: available.toString(), decimals });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/app/components/MarketsTable.js
+++ b/frontend/app/components/MarketsTable.js
@@ -16,6 +16,7 @@ import { formatCurrency, formatPercentage } from "../utils/formatting"
 import { getRiskRatingText, getRiskRatingColor } from "../utils/riskRating"
 import CoverageModal from "./CoverageModal"
 import usePools from "../../hooks/usePools"
+import useCoverAvailable from "../../hooks/useCoverAvailable"
 import { utils as ethersUtils, BigNumber } from "ethers"
 import {
   getTokenName,
@@ -33,6 +34,7 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
   const [modalOpen, setModalOpen] = useState(false)
   const [selectedPool, setSelectedPool] = useState(null)
   const { pools, loading } = usePools()
+  const { amount: availableStr, decimals: availableDecimals, loading: availableLoading } = useCoverAvailable()
   const [typeFilter, setTypeFilter] = useState("all") // 'all', 'protocol', 'stablecoin', 'lst'
   const [sortConfig, setSortConfig] = useState({ key: "tvl", direction: "desc" })
 
@@ -85,13 +87,16 @@ export default function MarketsTable({ displayCurrency, mode = "purchase" }) {
     grouped[pool.id] = entry
   }
 
+  const globalAvailable = availableLoading
+    ? 0
+    : Number(ethersUtils.formatUnits(availableStr || "0", availableDecimals))
+
   const markets = Object.values(grouped).map((m) => {
     const premiums = m.pools.map((p) => p.premium)
     const minPremium = premiums.length ? Math.min(...premiums) : 0
-    const available = m.pools.reduce((acc, p) => acc + p.capacity, 0)
     return {
       ...m,
-      coverAvailable: available,
+      coverAvailable: globalAvailable,
       premium: minPremium,
     }
   })

--- a/frontend/hooks/useCoverAvailable.js
+++ b/frontend/hooks/useCoverAvailable.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+
+export default function useCoverAvailable(deployment) {
+  const [amount, setAmount] = useState('0')
+  const [decimals, setDecimals] = useState(18)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const depParam = deployment ? `?deployment=${deployment}` : ''
+        const res = await fetch(`/api/capitalpool/available${depParam}`)
+        if (res.ok) {
+          const data = await res.json()
+          setAmount(data.available ?? '0')
+          setDecimals(data.decimals ?? 18)
+        }
+      } catch (err) {
+        console.error('Failed to load cover available', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [deployment])
+
+  return { amount, decimals, loading }
+}


### PR DESCRIPTION
## Summary
- compute cover availability from capital pool
- expose new API endpoint to read NAV and unsettled payouts
- show this value in the markets table

## Testing
- `npm test` *(fails: ENOENT no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688cf8560404832e802f38b2a7a52e46